### PR TITLE
VEGA-839: Always extract the branch name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.6/pact-1.88.6-linux-x86_64.tar.gz
           tar xzf pact-1.88.6-linux-x86_64.tar.gz
           echo "$PWD/pact/bin" >> $GITHUB_PATH
-      
+
       - name: Run Tests
         run: |
           gotestsum --junitfile /tmp/test-results/unit-tests.xml -- ./... -coverprofile=/tmp/test-coverage.txt
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run linting
         uses: golangci/golangci-lint-action@v2
-  
+
   acceptance-test:
     name: Acceptance Tests
     runs-on: ubuntu-latest
@@ -114,7 +114,7 @@ jobs:
       - name: Run pa11y
         run: |
           docker-compose -f docker/docker-compose.ci.yml run --entrypoint="pa11y-ci" puppeteer
-      
+
       - name: Run Lighthouse
         run: |
           docker-compose -f docker/docker-compose.ci.yml run --entrypoint="lhci autorun" puppeteer
@@ -150,7 +150,12 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Extract branch name
-        run: echo BRANCH_NAME=${{ github.head_ref }} >> $GITHUB_ENV
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "push" ]; then
+            echo BRANCH_NAME=main >> $GITHUB_ENV
+          else
+            echo BRANCH_NAME=${{ github.head_ref }} >> $GITHUB_ENV
+          fi
         id: extract_branch
       - uses: unfor19/install-aws-cli-action@v1
 
@@ -171,7 +176,7 @@ jobs:
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true
-      
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -181,13 +186,13 @@ jobs:
           role-to-assume: arn:aws:iam::311462405659:role/sirius-actions-ci
           role-duration-seconds: 3600
           role-session-name: GitHubActions
-      
+
       - name: ECR Login
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registries: 311462405659
-      
+
       - name: Push Container
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -201,7 +206,7 @@ jobs:
           else
             docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.bump_version.outputs.tag }}
           fi
-      
+
   push-tags:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
`github.head_ref` is only set on pull request events, so we should handle push events differently. There isn't an alternative variable, but we can only push to the main branch so we know that will be the branch name.