### PR TITLE
VEGA-829: View all cases

### DIFF
--- a/cypress/integration/cases.spec.js
+++ b/cypress/integration/cases.spec.js
@@ -1,0 +1,19 @@
+describe("Dashboard", () => {
+    beforeEach(() => {
+        cy.setCookie("Other", "other");
+        cy.setCookie("XSRF-TOKEN", "abcde");
+        cy.visit("/all-cases");
+    });
+
+    it("shows your cases", () => {
+        cy.title().should('contain', 'Your cases');
+        cy.get('h1').should('contain', 'Your cases');
+
+        const $row = cy.get('table > tbody > tr');
+        $row.should('contain', 'Adrian Kurkjian');
+        $row.should('contain', 'PF');
+        $row.should('contain', '12 May 2021');
+        $row.should('contain', 'Perfect');
+        $row.contains('7000-8548-8461').should('have.attr', 'href').should('contain', '/person/23/36');
+    });
+});

--- a/internal/server/all_cases.go
+++ b/internal/server/all_cases.go
@@ -11,6 +11,11 @@ type CasesClient interface {
 	MyDetails(sirius.Context) (sirius.MyDetails, error)
 }
 
+type allCasesVars struct {
+	Cases      []sirius.Case
+	Pagination *sirius.Pagination
+}
+
 func cases(client CasesClient, tmpl Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		if r.Method != http.MethodGet {
@@ -29,11 +34,9 @@ func cases(client CasesClient, tmpl Template) Handler {
 			return err
 		}
 
-		vars := dashboardVars{
-			Path:       r.URL.Path,
+		vars := allCasesVars{
 			Cases:      myCases,
 			Pagination: pagination,
-			ShowStatus: true,
 		}
 
 		return tmpl.ExecuteTemplate(w, "page", vars)

--- a/internal/server/all_cases.go
+++ b/internal/server/all_cases.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+)
+
+type CasesClient interface {
+	CasesByAssignee(sirius.Context, int, string, int) ([]sirius.Case, *sirius.Pagination, error)
+	MyDetails(sirius.Context) (sirius.MyDetails, error)
+}
+
+func cases(client CasesClient, tmpl Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		if r.Method != http.MethodGet {
+			return StatusError(http.StatusMethodNotAllowed)
+		}
+
+		ctx := getContext(r)
+
+		myDetails, err := client.MyDetails(ctx)
+		if err != nil {
+			return err
+		}
+
+		myCases, pagination, err := client.CasesByAssignee(ctx, myDetails.ID, "", getPage(r))
+		if err != nil {
+			return err
+		}
+
+		vars := dashboardVars{
+			Path:       r.URL.Path,
+			Cases:      myCases,
+			Pagination: pagination,
+			ShowStatus: true,
+		}
+
+		return tmpl.ExecuteTemplate(w, "page", vars)
+	}
+}

--- a/internal/server/all_cases_test.go
+++ b/internal/server/all_cases_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCasesClient struct {
+	myDetails struct {
+		count   int
+		lastCtx sirius.Context
+		data    sirius.MyDetails
+		err     error
+	}
+	casesByAssignee struct {
+		count      int
+		lastCtx    sirius.Context
+		lastId     int
+		lastStatus string
+		lastPage   int
+		data       []sirius.Case
+		pagination *sirius.Pagination
+		err        error
+	}
+}
+
+func (m *mockCasesClient) MyDetails(ctx sirius.Context) (sirius.MyDetails, error) {
+	m.myDetails.count += 1
+	m.myDetails.lastCtx = ctx
+
+	return m.myDetails.data, m.myDetails.err
+}
+
+func (m *mockCasesClient) CasesByAssignee(ctx sirius.Context, id int, status string, page int) ([]sirius.Case, *sirius.Pagination, error) {
+	m.casesByAssignee.count += 1
+	m.casesByAssignee.lastCtx = ctx
+	m.casesByAssignee.lastId = id
+	m.casesByAssignee.lastStatus = status
+	m.casesByAssignee.lastPage = page
+
+	return m.casesByAssignee.data, m.casesByAssignee.pagination, m.casesByAssignee.err
+}
+
+func TestGetCases(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		ID: 14,
+	}
+	client.casesByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := cases(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(14, client.casesByAssignee.lastId)
+	assert.Equal("", client.casesByAssignee.lastStatus)
+	assert.Equal(1, client.casesByAssignee.lastPage)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(dashboardVars{
+		Path:       "/path",
+		Cases:      client.casesByAssignee.data,
+		ShowStatus: true,
+	}, template.lastVars)
+}
+
+func TestGetCasesPage(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		ID: 14,
+	}
+	client.casesByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path?page=4", nil)
+
+	err := cases(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(14, client.casesByAssignee.lastId)
+	assert.Equal("", client.casesByAssignee.lastStatus)
+	assert.Equal(4, client.casesByAssignee.lastPage)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(dashboardVars{
+		Path:       "/path",
+		Cases:      client.casesByAssignee.data,
+		ShowStatus: true,
+	}, template.lastVars)
+}
+
+func TestGetCasesMyDetailsError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockCasesClient{}
+	client.myDetails.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := cases(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(0, client.casesByAssignee.count)
+}
+
+func TestGetCasesQueryError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		ID: 14,
+	}
+	client.casesByAssignee.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := cases(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(14, client.casesByAssignee.lastId)
+	assert.Equal("", client.casesByAssignee.lastStatus)
+}
+
+func TestBadMethodCases(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockCasesClient{}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("DELETE", "/path", nil)
+
+	err := cases(client, template)(w, r)
+
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+
+	assert.Equal(0, client.myDetails.count)
+	assert.Equal(0, client.casesByAssignee.count)
+	assert.Equal(0, template.count)
+}

--- a/internal/server/all_cases_test.go
+++ b/internal/server/all_cases_test.go
@@ -78,10 +78,8 @@ func TestGetCases(t *testing.T) {
 
 	assert.Equal(1, template.count)
 	assert.Equal("page", template.lastName)
-	assert.Equal(dashboardVars{
-		Path:       "/path",
+	assert.Equal(allCasesVars{
 		Cases:      client.casesByAssignee.data,
-		ShowStatus: true,
 	}, template.lastVars)
 }
 
@@ -117,10 +115,8 @@ func TestGetCasesPage(t *testing.T) {
 
 	assert.Equal(1, template.count)
 	assert.Equal("page", template.lastName)
-	assert.Equal(dashboardVars{
-		Path:       "/path",
+	assert.Equal(allCasesVars{
 		Cases:      client.casesByAssignee.data,
-		ShowStatus: true,
 	}, template.lastVars)
 }
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -12,11 +12,8 @@ type DashboardClient interface {
 }
 
 type dashboardVars struct {
-	Path       string
 	Cases      []sirius.Case
 	Pagination *sirius.Pagination
-	ShowWorked bool
-	ShowStatus bool
 }
 
 func dashboard(client DashboardClient, tmpl Template) Handler {
@@ -38,10 +35,8 @@ func dashboard(client DashboardClient, tmpl Template) Handler {
 		}
 
 		vars := dashboardVars{
-			Path:       r.URL.Path,
 			Cases:      myCases,
 			Pagination: pagination,
-			ShowWorked: true,
 		}
 
 		return tmpl.ExecuteTemplate(w, "page", vars)

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -7,12 +7,16 @@ import (
 )
 
 type DashboardClient interface {
-	CasesByAssignee(sirius.Context, int) ([]sirius.Case, error)
+	CasesByAssignee(sirius.Context, int, string, int) ([]sirius.Case, *sirius.Pagination, error)
 	MyDetails(sirius.Context) (sirius.MyDetails, error)
 }
 
 type dashboardVars struct {
-	Cases []sirius.Case
+	Path       string
+	Cases      []sirius.Case
+	Pagination *sirius.Pagination
+	ShowWorked bool
+	ShowStatus bool
 }
 
 func dashboard(client DashboardClient, tmpl Template) Handler {
@@ -28,13 +32,16 @@ func dashboard(client DashboardClient, tmpl Template) Handler {
 			return err
 		}
 
-		myCases, err := client.CasesByAssignee(ctx, myDetails.ID)
+		myCases, pagination, err := client.CasesByAssignee(ctx, myDetails.ID, "Pending", getPage(r))
 		if err != nil {
 			return err
 		}
 
 		vars := dashboardVars{
-			Cases: myCases,
+			Path:       r.URL.Path,
+			Cases:      myCases,
+			Pagination: pagination,
+			ShowWorked: true,
 		}
 
 		return tmpl.ExecuteTemplate(w, "page", vars)

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -79,9 +79,7 @@ func TestGetDashboard(t *testing.T) {
 	assert.Equal(1, template.count)
 	assert.Equal("page", template.lastName)
 	assert.Equal(dashboardVars{
-		Path:       "/path",
 		Cases:      client.casesByAssignee.data,
-		ShowWorked: true,
 	}, template.lastVars)
 }
 
@@ -118,9 +116,7 @@ func TestGetDashboardPage(t *testing.T) {
 	assert.Equal(1, template.count)
 	assert.Equal("page", template.lastName)
 	assert.Equal(dashboardVars{
-		Path:       "/path",
 		Cases:      client.casesByAssignee.data,
-		ShowWorked: true,
 	}, template.lastVars)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,7 +40,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 
 	mux.Handle("/all-cases",
 		wrap(
-			cases(client, templates["dashboard.gotmpl"])))
+			cases(client, templates["all-cases.gotmpl"])))
 
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,10 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 		wrap(
 			tasks(client, templates["tasks.gotmpl"])))
 
+	mux.Handle("/all-cases",
+		wrap(
+			cases(client, templates["dashboard.gotmpl"])))
+
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
 
 	static := http.FileServer(http.Dir(webDir + "/static"))

--- a/internal/sirius/cases_by_assignee.go
+++ b/internal/sirius/cases_by_assignee.go
@@ -27,32 +27,46 @@ func (d Donor) DisplayName() string {
 	return d.Firstname + " " + d.Surname
 }
 
-func (c *Client) CasesByAssignee(ctx Context, id int) ([]Case, error) {
-	var v struct {
-		Cases []Case `json:"cases"`
+func (c *Client) CasesByAssignee(ctx Context, id int, status string, page int) ([]Case, *Pagination, error) {
+	filter := "caseType:lpa,active:true"
+
+	if status != "" {
+		filter = fmt.Sprintf("%s,status:%s", filter, status)
 	}
 
-	url := fmt.Sprintf("/api/v1/assignees/%d/cases?filter=caseType:lpa,status:Pending,active:true&sort=caseSubType:asc", id)
+	url := fmt.Sprintf("/api/v1/assignees/%d/cases?page=%d&filter=%s&sort=caseSubType:asc", id, page, filter)
 
 	req, err := c.newRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return v.Cases, err
+		return nil, nil, err
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return v.Cases, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return v.Cases, ErrUnauthorized
+		return nil, nil, ErrUnauthorized
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return v.Cases, newStatusError(resp)
+		return nil, nil, newStatusError(resp)
+	}
+
+	var v struct {
+		Pages apiPages `json:"pages"`
+		Total int      `json:"total"`
+		Limit int      `json:"limit"`
+		Cases []Case   `json:"cases"`
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&v)
-	return v.Cases, err
+	return v.Cases, &Pagination{
+		TotalItems:  v.Total,
+		CurrentPage: v.Pages.Current,
+		TotalPages:  v.Pages.Total,
+		PageSize:    v.Limit,
+	}, err
 }

--- a/internal/sirius/cases_by_assignee_test.go
+++ b/internal/sirius/cases_by_assignee_test.go
@@ -32,12 +32,83 @@ func TestCasesByAssignee(t *testing.T) {
 	}{
 		{
 			name:   "OK",
-			status: "Pending",
 			setup: func() {
 				pact.
 					AddInteraction().
 					Given("I have a pending case assigned").
 					UponReceiving("A request to get my cases").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/assignees/47/cases"),
+						Query: dsl.MapMatcher{
+							"filter": dsl.String("caseType:lpa,active:true"),
+							"sort":   dsl.String("caseSubType:asc"),
+							"page":   dsl.String("1"),
+						},
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusOK,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Body: dsl.Like(map[string]interface{}{
+							"total": dsl.Like(1),
+							"limit": dsl.Like(25),
+							"pages": dsl.Like(map[string]interface{}{
+								"current": dsl.Like(1),
+								"total":   dsl.Like(1),
+							}),
+							"cases": dsl.EachLike(map[string]interface{}{
+								"id":  dsl.Like(36),
+								"uId": dsl.Term("7000-8548-8461", `\d{4}-\d{4}-\d{4}`),
+								"donor": dsl.Like(map[string]interface{}{
+									"id":        dsl.Like(23),
+									"uId":       dsl.Term("7000-5382-4438", `\d{4}-\d{4}-\d{4}`),
+									"firstname": dsl.Like("Adrian"),
+									"surname":   dsl.Like("Kurkjian"),
+								}),
+								"caseSubtype": dsl.Term("pf", "hw|pf"),
+								"receiptDate": dsl.Term("12/05/2021", `\d{1,2}/\d{1,2}/\d{4}`),
+								"status":      dsl.Like("Perfect"),
+							}, 1),
+						}),
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			expectedCases: []Case{{
+				ID:  36,
+				Uid: "7000-8548-8461",
+				Donor: Donor{
+					ID:        23,
+					Uid:       "7000-5382-4438",
+					Firstname: "Adrian",
+					Surname:   "Kurkjian",
+				},
+				SubType:     "pf",
+				ReceiptDate: SiriusDate{time.Date(2021, 5, 12, 0, 0, 0, 0, time.UTC)},
+				Status:      "Perfect",
+			}},
+			expectedPagination: &Pagination{
+				TotalItems:  1,
+				CurrentPage: 1,
+				TotalPages:  1,
+				PageSize:    25,
+			},
+		},
+		{
+			name:   "OK by status",
+			status: "Pending",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("I have a pending case assigned").
+					UponReceiving("A request to get my pending cases").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/assignees/47/cases"),
@@ -73,6 +144,7 @@ func TestCasesByAssignee(t *testing.T) {
 								}),
 								"caseSubtype": dsl.Term("hw", "hw|pf"),
 								"receiptDate": dsl.Term("14/05/2021", `\d{1,2}/\d{1,2}/\d{4}`),
+								"status":      dsl.Like("Pending"),
 							}, 1),
 						}),
 					})
@@ -92,59 +164,12 @@ func TestCasesByAssignee(t *testing.T) {
 				},
 				SubType:     "hw",
 				ReceiptDate: SiriusDate{time.Date(2021, 5, 14, 0, 0, 0, 0, time.UTC)},
+				Status:      "Pending",
 			}},
 			expectedPagination: &Pagination{
 				TotalItems:  1,
 				CurrentPage: 1,
 				TotalPages:  1,
-				PageSize:    25,
-			},
-		},
-		{
-			name:   "Invalid status",
-			status: "Unsupported",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to get my cases by status").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/api/v1/assignees/47/cases"),
-						Query: dsl.MapMatcher{
-							"filter": dsl.String("caseType:lpa,active:true,status:Unsupported"),
-							"sort":   dsl.String("caseSubType:asc"),
-							"page":   dsl.String("1"),
-						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status:  http.StatusOK,
-						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
-						Body: dsl.Like(map[string]interface{}{
-							"total": dsl.Like(0),
-							"limit": dsl.Like(25),
-							"pages": dsl.Like(map[string]interface{}{
-								"current": dsl.Like(1),
-								"total":   dsl.Like(0),
-							}),
-							"cases": []struct{}{},
-						}),
-					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-			expectedCases: []Case{},
-			expectedPagination: &Pagination{
-				TotalItems:  0,
-				CurrentPage: 1,
-				TotalPages:  0,
 				PageSize:    25,
 			},
 		},

--- a/internal/sirius/cases_by_assignee_test.go
+++ b/internal/sirius/cases_by_assignee_test.go
@@ -22,14 +22,17 @@ func TestCasesByAssignee(t *testing.T) {
 	defer pact.Teardown()
 
 	testCases := []struct {
-		name          string
-		setup         func()
-		cookies       []*http.Cookie
-		expectedCases []Case
-		expectedError error
+		name               string
+		status             string
+		setup              func()
+		cookies            []*http.Cookie
+		expectedCases      []Case
+		expectedPagination *Pagination
+		expectedError      error
 	}{
 		{
-			name: "OK",
+			name:   "OK",
+			status: "Pending",
 			setup: func() {
 				pact.
 					AddInteraction().
@@ -39,8 +42,9 @@ func TestCasesByAssignee(t *testing.T) {
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/assignees/47/cases"),
 						Query: dsl.MapMatcher{
-							"filter": dsl.String("caseType:lpa,status:Pending,active:true"),
+							"filter": dsl.String("caseType:lpa,active:true,status:Pending"),
 							"sort":   dsl.String("caseSubType:asc"),
+							"page":   dsl.String("1"),
 						},
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
@@ -52,6 +56,12 @@ func TestCasesByAssignee(t *testing.T) {
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 						Body: dsl.Like(map[string]interface{}{
+							"total": dsl.Like(1),
+							"limit": dsl.Like(25),
+							"pages": dsl.Like(map[string]interface{}{
+								"current": dsl.Like(1),
+								"total":   dsl.Like(1),
+							}),
 							"cases": dsl.EachLike(map[string]interface{}{
 								"id":  dsl.Like(58),
 								"uId": dsl.Term("7000-2830-9492", `\d{4}-\d{4}-\d{4}`),
@@ -83,8 +93,61 @@ func TestCasesByAssignee(t *testing.T) {
 				SubType:     "hw",
 				ReceiptDate: SiriusDate{time.Date(2021, 5, 14, 0, 0, 0, 0, time.UTC)},
 			}},
+			expectedPagination: &Pagination{
+				TotalItems:  1,
+				CurrentPage: 1,
+				TotalPages:  1,
+				PageSize:    25,
+			},
 		},
-
+		{
+			name:   "Invalid status",
+			status: "Unsupported",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("I have a pending case assigned").
+					UponReceiving("A request to get my cases by status").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/assignees/47/cases"),
+						Query: dsl.MapMatcher{
+							"filter": dsl.String("caseType:lpa,active:true,status:Unsupported"),
+							"sort":   dsl.String("caseSubType:asc"),
+							"page":   dsl.String("1"),
+						},
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusOK,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Body: dsl.Like(map[string]interface{}{
+							"total": dsl.Like(0),
+							"limit": dsl.Like(25),
+							"pages": dsl.Like(map[string]interface{}{
+								"current": dsl.Like(1),
+								"total":   dsl.Like(0),
+							}),
+							"cases": []struct{}{},
+						}),
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			expectedCases: []Case{},
+			expectedPagination: &Pagination{
+				TotalItems:  0,
+				CurrentPage: 1,
+				TotalPages:  0,
+				PageSize:    25,
+			},
+		},
 		{
 			name: "Unauthorized",
 			setup: func() {
@@ -96,8 +159,9 @@ func TestCasesByAssignee(t *testing.T) {
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/assignees/47/cases"),
 						Query: dsl.MapMatcher{
-							"filter": dsl.String("caseType:lpa,status:Pending,active:true"),
+							"filter": dsl.String("caseType:lpa,active:true"),
 							"sort":   dsl.String("caseSubType:asc"),
+							"page":   dsl.String("1"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -115,8 +179,9 @@ func TestCasesByAssignee(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				cases, err := client.CasesByAssignee(getContext(tc.cookies), 47)
+				cases, pagination, err := client.CasesByAssignee(getContext(tc.cookies), 47, tc.status, 1)
 				assert.Equal(t, tc.expectedCases, cases)
+				assert.Equal(t, tc.expectedPagination, pagination)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
@@ -130,10 +195,10 @@ func TestCasesByAssigneeStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.CasesByAssignee(getContext(nil), 47)
+	_, _, err := client.CasesByAssignee(getContext(nil), 47, "", 2)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/api/v1/assignees/47/cases?filter=caseType:lpa,status:Pending,active:true&sort=caseSubType:asc",
+		URL:    s.URL + "/api/v1/assignees/47/cases?page=2&filter=caseType:lpa,active:true&sort=caseSubType:asc",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/web/template/all-cases.gotmpl
+++ b/web/template/all-cases.gotmpl
@@ -10,13 +10,13 @@
       Contents
     </h2>
     <ul class="govuk-tabs__list">
-      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="/pending-cases">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
       </li>
-      <li class="govuk-tabs__list-item">
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
         <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
       </li>
     </ul>
@@ -33,7 +33,7 @@
         <th scope="col" class="govuk-table__header">Case</th>
         <th scope="col" class="govuk-table__header">LPA type</th>
         <th scope="col" class="govuk-table__header">Received</th>
-        <th scope="col" class="govuk-table__header">Worked</th>
+        <th scope="col" class="govuk-table__header">Case status</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -52,6 +52,9 @@
             {{ formatDate .ReceiptDate }}
           </td>
           <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--{{ statusColour .Status }}">
+              {{ .Status }}
+            </strong>
           </td>
         </tr>
       {{ else }}

--- a/web/template/dashboard.gotmpl
+++ b/web/template/dashboard.gotmpl
@@ -10,7 +10,7 @@
       Contents
     </h2>
     <ul class="govuk-tabs__list">
-      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <li class="govuk-tabs__list-item{{ if eq .Path "/pending-cases" }} govuk-tabs__list-item--selected{{ end }}">
         <a class="govuk-tabs__tab" href="/pending-cases">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item">
@@ -19,6 +19,8 @@
     </ul>
   </div>
 
+  {{ template "pagination" .Pagination }}
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
@@ -26,7 +28,9 @@
         <th scope="col" class="govuk-table__header">Case</th>
         <th scope="col" class="govuk-table__header">LPA type</th>
         <th scope="col" class="govuk-table__header">Received</th>
-        <th scope="col" class="govuk-table__header">Worked</th>
+        {{ if .ShowWorked }}
+          <th scope="col" class="govuk-table__header">Worked</th>
+        {{ end }}
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -44,8 +48,10 @@
           <td class="govuk-table__cell">
             {{ formatDate .ReceiptDate }}
           </td>
-          <td class="govuk-table__cell">
-          </td>
+          {{ if $.ShowWorked }}
+            <td class="govuk-table__cell">
+            </td>
+          {{ end }}
         </tr>
       {{ else }}
         <tr>

--- a/web/template/dashboard.gotmpl
+++ b/web/template/dashboard.gotmpl
@@ -24,6 +24,8 @@
 
   {{ template "pagination" .Pagination }}
 
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-top-5">
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/web/template/dashboard.gotmpl
+++ b/web/template/dashboard.gotmpl
@@ -16,6 +16,9 @@
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
       </li>
+      <li class="govuk-tabs__list-item{{ if eq .Path "/all-cases" }} govuk-tabs__list-item--selected{{ end }}">
+        <a class="govuk-tabs__tab" href="/all-cases">Cases</a>
+      </li>
     </ul>
   </div>
 
@@ -30,6 +33,9 @@
         <th scope="col" class="govuk-table__header">Received</th>
         {{ if .ShowWorked }}
           <th scope="col" class="govuk-table__header">Worked</th>
+        {{ end }}
+        {{ if .ShowStatus }}
+          <th scope="col" class="govuk-table__header">Case status</th>
         {{ end }}
       </tr>
     </thead>
@@ -50,6 +56,13 @@
           </td>
           {{ if $.ShowWorked }}
             <td class="govuk-table__cell">
+            </td>
+          {{ end }}
+          {{ if $.ShowStatus }}
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--{{ statusColour .Status }}">
+                {{ .Status }}
+              </strong>
             </td>
           {{ end }}
         </tr>

--- a/web/template/dashboard.gotmpl
+++ b/web/template/dashboard.gotmpl
@@ -17,7 +17,7 @@
         <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
       </li>
       <li class="govuk-tabs__list-item{{ if eq .Path "/all-cases" }} govuk-tabs__list-item--selected{{ end }}">
-        <a class="govuk-tabs__tab" href="/all-cases">Cases</a>
+        <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
       </li>
     </ul>
   </div>

--- a/web/template/tasks.gotmpl
+++ b/web/template/tasks.gotmpl
@@ -16,6 +16,9 @@
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
         <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
       </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="/all-cases">Cases</a>
+      </li>
     </ul>
   </div>
 

--- a/web/template/tasks.gotmpl
+++ b/web/template/tasks.gotmpl
@@ -17,7 +17,7 @@
         <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/all-cases">Cases</a>
+        <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
       </li>
     </ul>
   </div>

--- a/web/template/tasks.gotmpl
+++ b/web/template/tasks.gotmpl
@@ -24,6 +24,8 @@
 
   {{ template "pagination" .Pagination }}
 
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-top-5">
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">


### PR DESCRIPTION
Adds filtering and pagination to the `CasesByAssignee` API call, so it can be shared between this handler and pending-cases.

The new handler also shares the `dashboard` template, but with slightly different columns based on flags.

Adds links from existing tabs/pages.

Fixes VEGA-829

<details><summary>Preview</summary>

![image](https://user-images.githubusercontent.com/100852/119472639-4f3fbb00-bd42-11eb-9e37-dc843c0cca44.png)

</details>