### PR TITLE
Use prefix in links and redirects

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,7 +28,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/", http.RedirectHandler("/pending-cases", http.StatusFound))
+	mux.Handle("/", http.RedirectHandler(prefix+"/pending-cases", http.StatusFound))
 
 	mux.Handle("/pending-cases",
 		wrap(

--- a/web/template/all-cases.gotmpl
+++ b/web/template/all-cases.gotmpl
@@ -11,13 +11,13 @@
     </h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/pending-cases">Pending cases</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/pending-cases" }}">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/tasks" }}">Tasks</a>
       </li>
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/all-cases" }}">All cases</a>
       </li>
     </ul>
   </div>

--- a/web/template/dashboard.gotmpl
+++ b/web/template/dashboard.gotmpl
@@ -11,13 +11,13 @@
     </h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="/pending-cases">Pending cases</a>
+        <a class="govuk-tabs__tab" href="{{prefix "/pending-cases" }}">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
+        <a class="govuk-tabs__tab" href="{{prefix "/tasks" }}">Tasks</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
+        <a class="govuk-tabs__tab" href="{{prefix "/all-cases" }}">All cases</a>
       </li>
     </ul>
   </div>

--- a/web/template/tasks.gotmpl
+++ b/web/template/tasks.gotmpl
@@ -11,13 +11,13 @@
     </h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/pending-cases">Pending cases</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/pending-cases" }}">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="/tasks">Tasks</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/tasks" }}">Tasks</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="/all-cases">All cases</a>
+        <a class="govuk-tabs__tab" href="{{ prefix "/all-cases" }}">All cases</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
So that it can be hosted at `/lpa/dashboard`