### PR TITLE
Determine correct landing page

### DIFF
--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+)
+
+type LandingPageClient interface {
+	MyDetails(sirius.Context) (sirius.MyDetails, error)
+}
+
+func landingPage(client LandingPageClient) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		if r.Method != http.MethodGet {
+			return StatusError(http.StatusMethodNotAllowed)
+		}
+
+		ctx := getContext(r)
+
+		myDetails, err := client.MyDetails(ctx)
+		if err != nil {
+			return err
+		}
+
+		if myDetails.IsManager() {
+			return RedirectError("/teams/central")
+		} else {
+			return RedirectError("/pending-cases")
+		}
+	}
+}

--- a/internal/server/landing_page_test.go
+++ b/internal/server/landing_page_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLandingPageClient struct {
+	myDetails struct {
+		count   int
+		lastCtx sirius.Context
+		data    sirius.MyDetails
+		err     error
+	}
+}
+
+func (m *mockLandingPageClient) MyDetails(ctx sirius.Context) (sirius.MyDetails, error) {
+	m.myDetails.count += 1
+	m.myDetails.lastCtx = ctx
+
+	return m.myDetails.data, m.myDetails.err
+}
+
+func TestGetLandingPageManager(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockLandingPageClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := landingPage(client)(w, r)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(RedirectError("/teams/central"), err)
+}
+
+func TestGetLandingPageCaseWorker(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockLandingPageClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{},
+	}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := landingPage(client)(w, r)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(RedirectError("/pending-cases"), err)
+}
+
+func TestGetLandingPageMyDetailsError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockLandingPageClient{}
+	client.myDetails.err = expectedError
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := landingPage(client)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+}
+
+func TestBadMethodLandingPage(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockLandingPageClient{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("DELETE", "/path", nil)
+
+	err := landingPage(client)(w, r)
+
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/", http.RedirectHandler(prefix+"/pending-cases", http.StatusFound))
+	mux.Handle("/", wrap(landingPage(client)))
 
 	mux.Handle("/pending-cases",
 		wrap(


### PR DESCRIPTION
When a user goes to `/`, they should be redirected to `/pending-cases` if they're a case worker and `/teams/central` if they're a manager.

Fixes VEGA-812