### PR TITLE
Improve CI processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,23 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Build LPA Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+      - name: Build Images
+        run: |
+          docker-compose -f docker/docker-compose.ci.yml build --parallel app pact-stub
+          mkdir -p /tmp/images
+          docker save -o /tmp/images/app.tar docker_app:latest
+          docker save -o /tmp/images/pact-stub.tar docker_pact-stub:latest
+
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -68,12 +85,21 @@ jobs:
               echo "::set-output name=TAG::${{github.sha}}"
           fi
       - name: Publish pacts
+        if: github.actor != 'dependabot[bot]'
         env:
           PACT_DIR: ./pacts
           PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
           PACT_BROKER_USERNAME: admin
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
         run: PACT_TAG=${{ github.head_ref }} PACT_CONSUMER_VERSION=${{ steps.pact_tag.outputs.TAG }} go run internal/pact/publish.go
+      - name: Compare pacts
+        if: github.actor == 'dependabot[bot]'
+        env:
+          PACT_DIR: ./pacts
+          PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
+        run: |
+          curl ${PACT_BROKER_URL}/pacts/provider/sirius/consumer/sirius-lpa-dashboard/latest > /tmp/latest-pact.json
+          (diff <(jq --sort-keys . ${PACT_DIR}/sirius-lpa-dashboard-sirius.json) <(jq --sort-keys . /tmp/latest-pact.json) || true) | (! grep '<')
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v1
         with:
@@ -98,9 +124,16 @@ jobs:
   acceptance-test:
     name: Acceptance Tests
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - build
+      - test
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -110,6 +143,11 @@ jobs:
         run: |
           docker container create --name temp -v pacts_data:/root hello-world
           docker cp ./pacts/sirius-lpa-dashboard-sirius.json temp:/root/sirius-lpa-dashboard-sirius.json
+
+      - name: Restore images
+        run: |
+          docker load -i /tmp/images/app.tar
+          docker load -i /tmp/images/pact-stub.tar
 
       - name: Run pa11y
         run: |
@@ -122,9 +160,16 @@ jobs:
   cypress:
     name: Cypress
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - build
+      - test
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -134,14 +179,19 @@ jobs:
         run: |
           docker container create --name temp -v pacts_data:/root hello-world
           docker cp ./pacts/sirius-lpa-dashboard-sirius.json temp:/root/sirius-lpa-dashboard-sirius.json
+      - name: Restore images
+        run: |
+          docker load -i /tmp/images/app.tar
+          docker load -i /tmp/images/pact-stub.tar
       - name: Run cypress
         run: |
           docker-compose -f docker/docker-compose.ci.yml run cypress
 
-  build:
+  push:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
-    needs: ['test', 'lint', 'acceptance-test', 'cypress']
+    needs: ['build', 'test', 'lint', 'acceptance-test', 'cypress']
+    if: github.actor != 'dependabot[bot]'
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}
@@ -159,9 +209,15 @@ jobs:
         id: extract_branch
       - uses: unfor19/install-aws-cli-action@v1
 
-      - name: Build Container
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+      - name: Restore Image
         run: |
-          docker build --tag sirius-lpa-dashboard:latest -f docker/sirius-lpa-dashboard/Dockerfile .
+          docker load -i /tmp/images/app.tar
+          docker tag docker_app:latest sirius-lpa-dashboard:latest
       - name: Scan
         run: |
           docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy sirius-lpa-dashboard:latest
@@ -210,7 +266,7 @@ jobs:
 
   push-tags:
     runs-on: ubuntu-latest
-    needs: build
+    needs: push
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
@@ -231,7 +287,7 @@ jobs:
 
       - name: Push Tag to Parameter Store
         run: |
-          aws ssm put-parameter --name "opg-sirius-lpa-dashboard-latest-green-build" --type "String" --value "${{ needs.build.outputs.tag}}" --overwrite --region=eu-west-1
+          aws ssm put-parameter --name "opg-sirius-lpa-dashboard-latest-green-build" --type "String" --value "${{ needs.push.outputs.tag}}" --overwrite --region=eu-west-1
 
       - name: Trigger Dev Deploy
         shell: bash


### PR DESCRIPTION
Backporting some changes from the user management repo to speed up CI and make dependabot work.

- Build and cache images up-front so they're not rebuilt for acceptance testing steps
- Compare Pacts to latest if building for dependabot, rather than pushing to the broker (because dependabot doesn't have write access)
- Don't push images if building for dependabot (because dependabot doesn't have write access)