### PR TITLE
VEGA-835/VEGA-836: Manager view of caseworker dashboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           files: /tmp/test-coverage.txt
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
       - name: Persist Pacts
         uses: actions/upload-artifact@v2

--- a/cypress/integration/user-all-cases.spec.js
+++ b/cypress/integration/user-all-cases.spec.js
@@ -1,0 +1,21 @@
+describe("All of another user's cases", () => {
+  beforeEach(() => {
+      cy.setCookie("Other", "other");
+      cy.setCookie("XSRF-TOKEN", "abcde");
+      cy.visit("/users/all-cases/47");
+  });
+
+  it("shows all the user's cases", () => {
+      cy.title().should('contain', 'John');
+      cy.get('h1').should('contain', 'John');
+
+      cy.get('.govuk-tabs__list-item--selected').should('contain', 'All cases');
+
+      const $row = cy.get('table > tbody > tr');
+      $row.should('contain', 'Adrian Kurkjian');
+      $row.should('contain', 'PF');
+      $row.should('contain', '12 May 2021');
+      $row.get('a').contains('7000-8548-8461').should('have.attr', 'href').should('contain', '/person/23/36');
+      $row.get('.govuk-tag').should('contain', 'Perfect');
+  });
+});

--- a/cypress/integration/user-all-cases.spec.js
+++ b/cypress/integration/user-all-cases.spec.js
@@ -9,6 +9,8 @@ describe("All of another user's cases", () => {
       cy.title().should('contain', 'John');
       cy.get('h1').should('contain', 'John');
 
+      cy.get('.govuk-back-link').should('contain', 'Cool Team');
+
       cy.get('.govuk-tabs__list-item--selected').should('contain', 'All cases');
 
       const $row = cy.get('table > tbody > tr');

--- a/cypress/integration/user-pending-cases.spec.js
+++ b/cypress/integration/user-pending-cases.spec.js
@@ -9,6 +9,8 @@ describe("Another user's pending cases", () => {
         cy.title().should('contain', 'John');
         cy.get('h1').should('contain', 'John');
 
+        cy.get('.govuk-back-link').should('contain', 'Cool Team');
+
         cy.get('.govuk-tabs__list-item--selected').should('contain', 'Pending cases');
 
         const $row = cy.get('table > tbody > tr');

--- a/cypress/integration/user-pending-cases.spec.js
+++ b/cypress/integration/user-pending-cases.spec.js
@@ -1,18 +1,21 @@
-describe("Pending cases", () => {
+describe("Another user's pending cases", () => {
     beforeEach(() => {
         cy.setCookie("Other", "other");
         cy.setCookie("XSRF-TOKEN", "abcde");
         cy.visit("/users/pending-cases/47");
     });
 
-    it("shows your cases", () => {
+    it("shows the user's pending cases", () => {
         cy.title().should('contain', 'John');
         cy.get('h1').should('contain', 'John');
+
+        cy.get('.govuk-tabs__list-item--selected').should('contain', 'Pending cases');
 
         const $row = cy.get('table > tbody > tr');
         $row.should('contain', 'Wilma Ruthman');
         $row.should('contain', 'HW');
         $row.should('contain', '14 May 2021');
         $row.get('a').contains('7000-2830-9492').should('have.attr', 'href').should('contain', '/person/17/58');
+        $row.get('.govuk-tag').should('contain', 'Pending');
     });
 });

--- a/cypress/integration/user-tasks.spec.js
+++ b/cypress/integration/user-tasks.spec.js
@@ -9,6 +9,8 @@ describe("Another user's tasks", () => {
       cy.title().should('contain', 'John');
       cy.get('h1').should('contain', 'John');
 
+      cy.get('.govuk-back-link').should('contain', 'Cool Team');
+
       cy.get('.govuk-tabs__list-item--selected').should('contain', 'Tasks');
 
       const $row = cy.get('table > tbody > tr');

--- a/cypress/integration/user-tasks.spec.js
+++ b/cypress/integration/user-tasks.spec.js
@@ -1,0 +1,21 @@
+describe("Another user's tasks", () => {
+  beforeEach(() => {
+      cy.setCookie("Other", "other");
+      cy.setCookie("XSRF-TOKEN", "abcde");
+      cy.visit("/users/tasks/47");
+  });
+
+  it("shows the user's tasks", () => {
+      cy.title().should('contain', 'John');
+      cy.get('h1').should('contain', 'John');
+
+      cy.get('.govuk-tabs__list-item--selected').should('contain', 'Tasks');
+
+      const $row = cy.get('table > tbody > tr');
+      $row.should('contain', 'Wilma Ruthman');
+      $row.should('contain', 'HW');
+      $row.should('contain', '1 task');
+      $row.get('a').contains('7000-2830-9492').should('have.attr', 'href').should('contain', '/person/17/58');
+      $row.get('.govuk-tag').should('contain', 'Pending');
+  });
+});

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,9 @@ type Client interface {
 	RequestNextCasesClient
 	TasksClient
 	TeamWorkInProgressClient
+	UserAllCasesClient
 	UserPendingCasesClient
+	UserTasksClient
 }
 
 type Template interface {
@@ -60,6 +62,14 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	mux.Handle("/users/pending-cases/",
 		wrap(
 			userPendingCases(client, templates["user-pending-cases.gotmpl"])))
+
+	mux.Handle("/users/tasks/",
+		wrap(
+			userTasks(client, templates["user-tasks.gotmpl"])))
+
+	mux.Handle("/users/all-cases/",
+		wrap(
+			userAllCases(client, templates["user-all-cases.gotmpl"])))
 
 	mux.Handle("/request-next-cases",
 		wrap(

--- a/internal/server/user_all_cases.go
+++ b/internal/server/user_all_cases.go
@@ -16,6 +16,7 @@ type UserAllCasesClient interface {
 
 type userAllCasesVars struct {
 	Assignee   sirius.Assignee
+	Team       sirius.Team
 	Cases      []sirius.Case
 	Pagination *Pagination
 	XSRFToken  string
@@ -55,8 +56,14 @@ func userAllCases(client UserAllCasesClient, tmpl Template) Handler {
 			return err
 		}
 
+		var team sirius.Team
+		if len(assignee.Teams) > 0 {
+			team = assignee.Teams[0]
+		}
+
 		vars := userAllCasesVars{
 			Assignee:   assignee,
+			Team:       team,
 			Cases:      cases,
 			Pagination: newPagination(pagination),
 			XSRFToken:  ctx.XSRFToken,

--- a/internal/server/user_all_cases_test.go
+++ b/internal/server/user_all_cases_test.go
@@ -118,6 +118,10 @@ func TestGetUserAllCasesPage(t *testing.T) {
 	client.user.data = sirius.Assignee{
 		ID:          74,
 		DisplayName: "Elfriede Giesing",
+		Teams: []sirius.Team{{
+			ID:          281,
+			DisplayName: "Casework Team 6",
+		}},
 	}
 	client.casesByAssignee.data = []sirius.Case{{
 		ID: 78,
@@ -150,6 +154,7 @@ func TestGetUserAllCasesPage(t *testing.T) {
 	assert.Equal("page", template.lastName)
 	assert.Equal(userAllCasesVars{
 		Assignee:   client.user.data,
+		Team:       client.user.data.Teams[0],
 		Cases:      client.casesByAssignee.data,
 		Pagination: newPagination(client.casesByAssignee.pagination),
 	}, template.lastVars)

--- a/internal/server/user_all_cases_test.go
+++ b/internal/server/user_all_cases_test.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockUserAllCasesClient struct {
+	myDetails struct {
+		count   int
+		lastCtx sirius.Context
+		data    sirius.MyDetails
+		err     error
+	}
+	user struct {
+		count   int
+		lastCtx sirius.Context
+		lastId  int
+		data    sirius.Assignee
+		err     error
+	}
+	casesByAssignee struct {
+		count        int
+		lastCtx      sirius.Context
+		lastId       int
+		lastCriteria sirius.Criteria
+		data         []sirius.Case
+		pagination   *sirius.Pagination
+		err          error
+	}
+}
+
+func (m *mockUserAllCasesClient) MyDetails(ctx sirius.Context) (sirius.MyDetails, error) {
+	m.myDetails.count += 1
+	m.myDetails.lastCtx = ctx
+
+	return m.myDetails.data, m.myDetails.err
+}
+
+func (m *mockUserAllCasesClient) User(ctx sirius.Context, id int) (sirius.Assignee, error) {
+	m.user.count += 1
+	m.user.lastCtx = ctx
+	m.user.lastId = id
+
+	return m.user.data, m.user.err
+}
+
+func (m *mockUserAllCasesClient) CasesByAssignee(ctx sirius.Context, id int, criteria sirius.Criteria) ([]sirius.Case, *sirius.Pagination, error) {
+	m.casesByAssignee.count += 1
+	m.casesByAssignee.lastCtx = ctx
+	m.casesByAssignee.lastId = id
+	m.casesByAssignee.lastCriteria = criteria
+
+	return m.casesByAssignee.data, m.casesByAssignee.pagination, m.casesByAssignee.err
+}
+
+func TestGetUserAllCases(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	client.casesByAssignee.pagination = &sirius.Pagination{
+		TotalItems: 20,
+	}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(74, client.casesByAssignee.lastId)
+	assert.Equal(sirius.Criteria{}.Page(1).Sort("receiptDate", sirius.Ascending), client.casesByAssignee.lastCriteria)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(userAllCasesVars{
+		Assignee:   client.user.data,
+		Cases:      client.casesByAssignee.data,
+		Pagination: newPagination(client.casesByAssignee.pagination),
+	}, template.lastVars)
+}
+
+func TestGetUserAllCasesPage(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	client.casesByAssignee.pagination = &sirius.Pagination{}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74?page=4", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(74, client.casesByAssignee.lastId)
+	assert.Equal(sirius.Criteria{}.Page(4).Sort("receiptDate", sirius.Ascending), client.casesByAssignee.lastCriteria)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(userAllCasesVars{
+		Assignee:   client.user.data,
+		Cases:      client.casesByAssignee.data,
+		Pagination: newPagination(client.casesByAssignee.pagination),
+	}, template.lastVars)
+}
+
+func TestGetUserAllCasesForbidden(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Case Worker"},
+	}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Equal(StatusError(http.StatusForbidden), err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesByAssignee.count)
+}
+
+func TestGetUserAllCasesMyDetailsError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesByAssignee.count)
+}
+
+func TestGetUserAllCasesGetUserError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(0, client.casesByAssignee.count)
+}
+
+func TestGetUserAllCasesQueryError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserAllCasesClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesByAssignee.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesByAssignee.count)
+	assert.Equal(getContext(r), client.casesByAssignee.lastCtx)
+	assert.Equal(74, client.casesByAssignee.lastId)
+	assert.Equal(sirius.Criteria{}.Page(1).Sort("receiptDate", sirius.Ascending), client.casesByAssignee.lastCriteria)
+}
+
+func TestBadMethodUserAllCases(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserAllCasesClient{}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("DELETE", "/users/all-cases/74", nil)
+
+	err := userAllCases(client, template)(w, r)
+
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesByAssignee.count)
+	assert.Equal(0, template.count)
+}

--- a/internal/server/user_pending_cases.go
+++ b/internal/server/user_pending_cases.go
@@ -16,6 +16,7 @@ type UserPendingCasesClient interface {
 
 type userPendingCasesVars struct {
 	Assignee   sirius.Assignee
+	Team       sirius.Team
 	Cases      []sirius.Case
 	Pagination *Pagination
 	XSRFToken  string
@@ -56,8 +57,14 @@ func userPendingCases(client UserPendingCasesClient, tmpl Template) Handler {
 			return err
 		}
 
+		var team sirius.Team
+		if len(assignee.Teams) > 0 {
+			team = assignee.Teams[0]
+		}
+
 		vars := userPendingCasesVars{
 			Assignee:   assignee,
+			Team:       team,
 			Cases:      cases,
 			Pagination: newPagination(pagination),
 			XSRFToken:  ctx.XSRFToken,

--- a/internal/server/user_pending_cases_test.go
+++ b/internal/server/user_pending_cases_test.go
@@ -118,6 +118,10 @@ func TestGetUserPendingCasesPage(t *testing.T) {
 	client.user.data = sirius.Assignee{
 		ID:          74,
 		DisplayName: "Elfriede Giesing",
+		Teams: []sirius.Team{{
+			ID:          281,
+			DisplayName: "Casework Team 6",
+		}},
 	}
 	client.casesByAssignee.data = []sirius.Case{{
 		ID: 78,
@@ -150,6 +154,7 @@ func TestGetUserPendingCasesPage(t *testing.T) {
 	assert.Equal("page", template.lastName)
 	assert.Equal(userPendingCasesVars{
 		Assignee:   client.user.data,
+		Team:       client.user.data.Teams[0],
 		Cases:      client.casesByAssignee.data,
 		Pagination: newPagination(client.casesByAssignee.pagination),
 	}, template.lastVars)

--- a/internal/server/user_tasks.go
+++ b/internal/server/user_tasks.go
@@ -16,6 +16,7 @@ type UserTasksClient interface {
 
 type userTasksVars struct {
 	Assignee   sirius.Assignee
+	Team       sirius.Team
 	Cases      []sirius.Case
 	Pagination *Pagination
 	XSRFToken  string
@@ -58,8 +59,14 @@ func userTasks(client UserTasksClient, tmpl Template) Handler {
 			return err
 		}
 
+		var team sirius.Team
+		if len(assignee.Teams) > 0 {
+			team = assignee.Teams[0]
+		}
+
 		vars := userTasksVars{
 			Assignee:   assignee,
+			Team:       team,
 			Cases:      cases,
 			Pagination: newPagination(pagination),
 			XSRFToken:  ctx.XSRFToken,

--- a/internal/server/user_tasks.go
+++ b/internal/server/user_tasks.go
@@ -8,20 +8,20 @@ import (
 	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
 )
 
-type UserPendingCasesClient interface {
-	CasesByAssignee(sirius.Context, int, sirius.Criteria) ([]sirius.Case, *sirius.Pagination, error)
+type UserTasksClient interface {
+	CasesWithOpenTasksByAssignee(sirius.Context, int, int) ([]sirius.Case, *sirius.Pagination, error)
 	MyDetails(sirius.Context) (sirius.MyDetails, error)
 	User(sirius.Context, int) (sirius.Assignee, error)
 }
 
-type userPendingCasesVars struct {
+type userTasksVars struct {
 	Assignee   sirius.Assignee
 	Cases      []sirius.Case
 	Pagination *Pagination
 	XSRFToken  string
 }
 
-func userPendingCases(client UserPendingCasesClient, tmpl Template) Handler {
+func userTasks(client UserTasksClient, tmpl Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		if r.Method != http.MethodGet {
 			return StatusError(http.StatusMethodNotAllowed)
@@ -38,7 +38,7 @@ func userPendingCases(client UserPendingCasesClient, tmpl Template) Handler {
 			return StatusError(http.StatusForbidden)
 		}
 
-		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/users/pending-cases/"))
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/users/tasks/"))
 		if err != nil {
 			return StatusError(http.StatusNotFound)
 		}
@@ -49,14 +49,16 @@ func userPendingCases(client UserPendingCasesClient, tmpl Template) Handler {
 			return err
 		}
 
-		criteria := sirius.Criteria{}.Filter("status", "Pending").Page(getPage(r)).Sort("receiptDate", sirius.Ascending)
-		cases, pagination, err := client.CasesByAssignee(ctx, id, criteria)
+		cases, pagination, err := client.CasesWithOpenTasksByAssignee(ctx, id, getPage(r))
+		if err != nil {
+			return err
+		}
 
 		if err != nil {
 			return err
 		}
 
-		vars := userPendingCasesVars{
+		vars := userTasksVars{
 			Assignee:   assignee,
 			Cases:      cases,
 			Pagination: newPagination(pagination),

--- a/internal/server/user_tasks_test.go
+++ b/internal/server/user_tasks_test.go
@@ -118,6 +118,10 @@ func TestGetUserTasksPage(t *testing.T) {
 	client.user.data = sirius.Assignee{
 		ID:          74,
 		DisplayName: "Elfriede Giesing",
+		Teams: []sirius.Team{{
+			ID:          281,
+			DisplayName: "Casework Team 6",
+		}},
 	}
 	client.casesWithOpenTasksByAssignee.data = []sirius.Case{{
 		ID: 78,
@@ -150,6 +154,7 @@ func TestGetUserTasksPage(t *testing.T) {
 	assert.Equal("page", template.lastName)
 	assert.Equal(userTasksVars{
 		Assignee:   client.user.data,
+		Team:       client.user.data.Teams[0],
 		Cases:      client.casesWithOpenTasksByAssignee.data,
 		Pagination: newPagination(client.casesWithOpenTasksByAssignee.pagination),
 	}, template.lastVars)

--- a/internal/server/user_tasks_test.go
+++ b/internal/server/user_tasks_test.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockUserTasksClient struct {
+	myDetails struct {
+		count   int
+		lastCtx sirius.Context
+		data    sirius.MyDetails
+		err     error
+	}
+	user struct {
+		count   int
+		lastCtx sirius.Context
+		lastId  int
+		data    sirius.Assignee
+		err     error
+	}
+	casesWithOpenTasksByAssignee struct {
+		count      int
+		lastCtx    sirius.Context
+		lastId     int
+		lastPage   int
+		data       []sirius.Case
+		pagination *sirius.Pagination
+		err        error
+	}
+}
+
+func (m *mockUserTasksClient) MyDetails(ctx sirius.Context) (sirius.MyDetails, error) {
+	m.myDetails.count += 1
+	m.myDetails.lastCtx = ctx
+
+	return m.myDetails.data, m.myDetails.err
+}
+
+func (m *mockUserTasksClient) User(ctx sirius.Context, id int) (sirius.Assignee, error) {
+	m.user.count += 1
+	m.user.lastCtx = ctx
+	m.user.lastId = id
+
+	return m.user.data, m.user.err
+}
+
+func (m *mockUserTasksClient) CasesWithOpenTasksByAssignee(ctx sirius.Context, id, page int) ([]sirius.Case, *sirius.Pagination, error) {
+	m.casesWithOpenTasksByAssignee.count += 1
+	m.casesWithOpenTasksByAssignee.lastCtx = ctx
+	m.casesWithOpenTasksByAssignee.lastId = id
+	m.casesWithOpenTasksByAssignee.lastPage = page
+
+	return m.casesWithOpenTasksByAssignee.data, m.casesWithOpenTasksByAssignee.pagination, m.casesWithOpenTasksByAssignee.err
+}
+
+func TestGetUserTasks(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserTasksClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesWithOpenTasksByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	client.casesWithOpenTasksByAssignee.pagination = &sirius.Pagination{
+		TotalItems: 20,
+	}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesWithOpenTasksByAssignee.count)
+	assert.Equal(getContext(r), client.casesWithOpenTasksByAssignee.lastCtx)
+	assert.Equal(74, client.casesWithOpenTasksByAssignee.lastId)
+	assert.Equal(1, client.casesWithOpenTasksByAssignee.lastPage)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(userTasksVars{
+		Assignee:   client.user.data,
+		Cases:      client.casesWithOpenTasksByAssignee.data,
+		Pagination: newPagination(client.casesWithOpenTasksByAssignee.pagination),
+	}, template.lastVars)
+}
+
+func TestGetUserTasksPage(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserTasksClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesWithOpenTasksByAssignee.data = []sirius.Case{{
+		ID: 78,
+		Donor: sirius.Donor{
+			ID: 79,
+		},
+	}}
+	client.casesWithOpenTasksByAssignee.pagination = &sirius.Pagination{}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74?page=4", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesWithOpenTasksByAssignee.count)
+	assert.Equal(getContext(r), client.casesWithOpenTasksByAssignee.lastCtx)
+	assert.Equal(74, client.casesWithOpenTasksByAssignee.lastId)
+	assert.Equal(4, client.casesWithOpenTasksByAssignee.lastPage)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(userTasksVars{
+		Assignee:   client.user.data,
+		Cases:      client.casesWithOpenTasksByAssignee.data,
+		Pagination: newPagination(client.casesWithOpenTasksByAssignee.pagination),
+	}, template.lastVars)
+}
+
+func TestGetUserTasksForbidden(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserTasksClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Case Worker"},
+	}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Equal(StatusError(http.StatusForbidden), err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesWithOpenTasksByAssignee.count)
+}
+
+func TestGetUserTasksMyDetailsError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserTasksClient{}
+	client.myDetails.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesWithOpenTasksByAssignee.count)
+}
+
+func TestGetUserTasksGetUserError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserTasksClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(0, client.casesWithOpenTasksByAssignee.count)
+}
+
+func TestGetUserTasksQueryError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUserTasksClient{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Manager"},
+	}
+	client.user.data = sirius.Assignee{
+		ID:          74,
+		DisplayName: "Elfriede Giesing",
+	}
+	client.casesWithOpenTasksByAssignee.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.myDetails.count)
+	assert.Equal(getContext(r), client.myDetails.lastCtx)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(getContext(r), client.user.lastCtx)
+	assert.Equal(74, client.user.lastId)
+
+	assert.Equal(1, client.casesWithOpenTasksByAssignee.count)
+	assert.Equal(getContext(r), client.casesWithOpenTasksByAssignee.lastCtx)
+	assert.Equal(74, client.casesWithOpenTasksByAssignee.lastId)
+	assert.Equal(1, client.casesWithOpenTasksByAssignee.lastPage)
+}
+
+func TestBadMethodUserTasks(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUserTasksClient{}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("DELETE", "/users/tasks/74", nil)
+
+	err := userTasks(client, template)(w, r)
+
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+
+	assert.Equal(0, client.user.count)
+	assert.Equal(0, client.casesWithOpenTasksByAssignee.count)
+	assert.Equal(0, template.count)
+}

--- a/internal/sirius/cases_by_assignee.go
+++ b/internal/sirius/cases_by_assignee.go
@@ -21,6 +21,7 @@ type Case struct {
 type Assignee struct {
 	ID          int    `json:"id"`
 	DisplayName string `json:"displayName"`
+	Teams       []Team `json:"teams"`
 }
 
 type Donor struct {

--- a/internal/sirius/user_test.go
+++ b/internal/sirius/user_test.go
@@ -44,6 +44,10 @@ func TestUser(t *testing.T) {
 						Body: dsl.Like(map[string]interface{}{
 							"id":          dsl.Like(47),
 							"displayName": dsl.Like("John"),
+							"teams": dsl.EachLike(map[string]interface{}{
+								"id":          66,
+								"displayName": "Cool Team",
+							}, 1),
 						}),
 					})
 			},
@@ -54,6 +58,12 @@ func TestUser(t *testing.T) {
 			expectedUser: Assignee{
 				ID:          47,
 				DisplayName: "John",
+				Teams: []Team{
+					{
+						ID:          66,
+						DisplayName: "Cool Team",
+					},
+				},
 			},
 		},
 

--- a/web/template/layout/page.gotmpl
+++ b/web/template/layout/page.gotmpl
@@ -28,10 +28,10 @@
 
       {{ template "header" . }}
 
-      <div class="govuk-width-container app-width-container">
+      <div class="govuk-width-container">
         {{ block "backlink" . }}{{ end }}
 
-        <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
+        <main class="govuk-main-wrapper" id="main-content" role="main">
           {{ block "main" . }}{{ end }}
         </main>
       </div>

--- a/web/template/user-all-cases.gotmpl
+++ b/web/template/user-all-cases.gotmpl
@@ -1,0 +1,70 @@
+{{ template "page" . }}
+
+{{ define "title" }}All cases - {{ .Assignee.DisplayName }}{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
+
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">
+      Contents
+    </h2>
+    <ul class="govuk-tabs__list">
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/pending-cases/%d" .Assignee.ID) }}">Pending cases</a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/tasks/%d" .Assignee.ID) }}">Tasks</a>
+      </li>
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/all-cases/%d" .Assignee.ID) }}">All cases</a>
+      </li>
+    </ul>
+  </div>
+
+  {{ template "pagination" .Pagination }}
+
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-top-5">
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Donor</th>
+        <th scope="col" class="govuk-table__header">Case</th>
+        <th scope="col" class="govuk-table__header">LPA type</th>
+        <th scope="col" class="govuk-table__header">Received</th>
+        <th scope="col" class="govuk-table__header">Status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {{ range .Cases }}
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">{{ .Donor.DisplayName }}</th>
+          <td class="govuk-table__cell">
+            <a href="{{ sirius (printf "/lpa/person/%d/%d" .Donor.ID .ID) }}" class="govuk-link">
+              {{ .Uid }}
+            </a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ upper .SubType }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ formatDate .ReceiptDate }}
+          </td>
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--{{ statusColour .Status }}">
+              {{ .Status }}
+            </strong>
+          </td>
+        </tr>
+      {{ else }}
+        <tr>
+          <td colspan="5">You currently have no cases assigned</td>
+        </tr>
+      {{ end }}
+    </tbody>
+  </table>
+
+  {{ template "duplicate-pagination" .Pagination }}
+
+{{ end }}

--- a/web/template/user-all-cases.gotmpl
+++ b/web/template/user-all-cases.gotmpl
@@ -2,6 +2,12 @@
 
 {{ define "title" }}All cases - {{ .Assignee.DisplayName }}{{ end }}
 
+{{ define "backlink" }}
+  {{ if .Team.ID }}
+    <a href="{{ prefix (printf "/teams/work-in-progress/%d" .Team.ID) }}" class="govuk-back-link">{{ .Team.DisplayName }}</a>
+  {{ end }}
+{{ end }}
+
 {{ define "main" }}
   <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
 

--- a/web/template/user-pending-cases.gotmpl
+++ b/web/template/user-pending-cases.gotmpl
@@ -1,6 +1,6 @@
 {{ template "page" . }}
 
-{{ define "title" }}{{ .Assignee.DisplayName }}{{ end }}
+{{ define "title" }}Pending cases - {{ .Assignee.DisplayName }}{{ end }}
 
 {{ define "main" }}
   <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
@@ -11,14 +11,14 @@
     </h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="{{ prefix (printf "/user/%d" .Assignee.ID) }}">Pending cases</a>
-      </li>
-      <!--<li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#">Tasks</a>
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/pending-cases/%d" .Assignee.ID) }}">Pending cases</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#">All cases</a>
-      </li>-->
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/tasks/%d" .Assignee.ID) }}">Tasks</a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/all-cases/%d" .Assignee.ID) }}">All cases</a>
+      </li>
     </ul>
   </div>
 

--- a/web/template/user-pending-cases.gotmpl
+++ b/web/template/user-pending-cases.gotmpl
@@ -2,6 +2,12 @@
 
 {{ define "title" }}Pending cases - {{ .Assignee.DisplayName }}{{ end }}
 
+{{ define "backlink" }}
+  {{ if .Team.ID }}
+    <a href="{{ prefix (printf "/teams/work-in-progress/%d" .Team.ID) }}" class="govuk-back-link">{{ .Team.DisplayName }}</a>
+  {{ end }}
+{{ end }}
+
 {{ define "main" }}
   <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
 

--- a/web/template/user-tasks.gotmpl
+++ b/web/template/user-tasks.gotmpl
@@ -1,0 +1,70 @@
+{{ template "page" . }}
+
+{{ define "title" }}Tasks - {{ .Assignee.DisplayName }}{{ end }}
+
+{{ define "main" }}
+  <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
+
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">
+      Contents
+    </h2>
+    <ul class="govuk-tabs__list">
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/pending-cases/%d" .Assignee.ID) }}">Pending cases</a>
+      </li>
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/tasks/%d" .Assignee.ID) }}">Tasks</a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="{{ prefix (printf "/users/all-cases/%d" .Assignee.ID) }}">All cases</a>
+      </li>
+    </ul>
+  </div>
+
+  {{ template "pagination" .Pagination }}
+
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-top-5">
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Donor</th>
+        <th scope="col" class="govuk-table__header">Case</th>
+        <th scope="col" class="govuk-table__header">LPA type</th>
+        <th scope="col" class="govuk-table__header">Open tasks per case</th>
+        <th scope="col" class="govuk-table__header">Case status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {{ range .Cases }}
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">{{ .Donor.DisplayName }}</th>
+          <td class="govuk-table__cell">
+            <a href="{{ sirius (printf "/lpa/person/%d/%d" .Donor.ID .ID) }}" class="govuk-link">
+              {{ .Uid }}
+            </a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ upper .SubType }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ .TaskCount }} {{ if eq .TaskCount 1 }}task{{ else }}tasks{{ end }}
+          </td>
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--{{ statusColour .Status }}">
+              {{ .Status }}
+            </strong>
+          </td>
+        </tr>
+      {{ else }}
+        <tr>
+          <td colspan="5">You currently have no cases assigned</td>
+        </tr>
+      {{ end }}
+    </tbody>
+  </table>
+
+  {{ template "duplicate-pagination" .Pagination }}
+
+{{ end }}

--- a/web/template/user-tasks.gotmpl
+++ b/web/template/user-tasks.gotmpl
@@ -2,6 +2,12 @@
 
 {{ define "title" }}Tasks - {{ .Assignee.DisplayName }}{{ end }}
 
+{{ define "backlink" }}
+  {{ if .Team.ID }}
+    <a href="{{ prefix (printf "/teams/work-in-progress/%d" .Team.ID) }}" class="govuk-back-link">{{ .Team.DisplayName }}</a>
+  {{ end }}
+{{ end }}
+
 {{ define "main" }}
   <h1 class="govuk-heading-xl">{{ .Assignee.DisplayName }}</h1>
 


### PR DESCRIPTION
**NB: Forked from VEGA-834. Once that's merged, this can be rebased against main**

Adds the full pending cases/all cases/tasks pages for the manager view of a caseworker. Includes table contents, navigation and backlinks to the team.

Adds expectation for `client.User()` to return the user's teams.

Fixes VEGA-835 and VEGA-836