### PR TITLE
VEGA-855: Only show Request cases button to case workers

### DIFF
--- a/internal/server/pending_cases.go
+++ b/internal/server/pending_cases.go
@@ -16,6 +16,7 @@ type pendingCasesVars struct {
 	Cases           []sirius.Case
 	Pagination      *Pagination
 	HasWorkableCase bool
+	CanRequestCase  bool
 	XSRFToken       string
 }
 
@@ -48,6 +49,7 @@ func pendingCases(client PendingCasesClient, tmpl Template) Handler {
 			Cases:           myCases,
 			Pagination:      newPagination(pagination),
 			HasWorkableCase: hasWorkableCase,
+			CanRequestCase:  myDetails.HasRole("Self Allocation User"),
 			XSRFToken:       ctx.XSRFToken,
 		}
 

--- a/internal/server/pending_cases_test.go
+++ b/internal/server/pending_cases_test.go
@@ -106,7 +106,8 @@ func TestGetPendingCasesPage(t *testing.T) {
 
 	client := &mockPendingCasesClient{}
 	client.myDetails.data = sirius.MyDetails{
-		ID: 14,
+		ID:    14,
+		Roles: []string{"Self Allocation User"},
 	}
 	client.casesByAssignee.data = []sirius.Case{{
 		ID: 78,
@@ -134,8 +135,9 @@ func TestGetPendingCasesPage(t *testing.T) {
 	assert.Equal(1, template.count)
 	assert.Equal("page", template.lastName)
 	assert.Equal(pendingCasesVars{
-		Cases:      client.casesByAssignee.data,
-		Pagination: newPagination(client.casesByAssignee.pagination),
+		CanRequestCase: true,
+		Cases:          client.casesByAssignee.data,
+		Pagination:     newPagination(client.casesByAssignee.pagination),
 	}, template.lastVars)
 }
 

--- a/internal/sirius/criteria.go
+++ b/internal/sirius/criteria.go
@@ -23,12 +23,12 @@ func (f filter) String() string {
 	return fmt.Sprintf("%s:%s", f.field, f.value)
 }
 
-type sort struct {
+type sortCriteria struct {
 	field string
 	order sortOrder
 }
 
-func (f sort) String() string {
+func (f sortCriteria) String() string {
 	return fmt.Sprintf("%s:%s", f.field, f.order)
 }
 
@@ -36,7 +36,7 @@ type Criteria struct {
 	page   int
 	limit  int
 	filter []filter
-	sort   []sort
+	sort   []sortCriteria
 }
 
 func (c Criteria) Page(id int) Criteria {
@@ -58,7 +58,7 @@ func (c Criteria) Filter(field string, value string) Criteria {
 }
 
 func (c Criteria) Sort(field string, order sortOrder) Criteria {
-	c.sort = append(c.sort, sort{
+	c.sort = append(c.sort, sortCriteria{
 		field: field,
 		order: order,
 	})

--- a/internal/sirius/my_details.go
+++ b/internal/sirius/my_details.go
@@ -20,14 +20,18 @@ type MyDetails struct {
 	Suspended   bool            `json:"suspended"`
 }
 
-func (md *MyDetails) IsManager() bool {
-	for _, role := range md.Roles {
-		if role == "Manager" {
+func (md *MyDetails) HasRole(role string) bool {
+	for _, myRole := range md.Roles {
+		if myRole == role {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (md *MyDetails) IsManager() bool {
+	return md.HasRole("Manager")
 }
 
 type MyDetailsTeam struct {

--- a/internal/sirius/my_details_test.go
+++ b/internal/sirius/my_details_test.go
@@ -149,3 +149,42 @@ func TestMyDetailsIsManager(t *testing.T) {
 		assert.Equal(tc.expected, myDetails.IsManager())
 	}
 }
+
+func TestMyDetailsHasRole(t *testing.T) {
+	testCases := []struct {
+		roles    []string
+		search   string
+		expected bool
+	}{
+		{
+			roles:    []string{},
+			search:   "POA User",
+			expected: false,
+		},
+		{
+			roles:    []string{"POA User"},
+			search:   "POA User",
+			expected: true,
+		},
+		{
+			roles:    []string{"Manager", "POA User", "OPG User"},
+			search:   "POA User",
+			expected: true,
+		},
+		{
+			roles:    []string{"Manager", "OPG User"},
+			search:   "POA User",
+			expected: false,
+		},
+	}
+
+	assert := assert.New(t)
+
+	for _, tc := range testCases {
+		myDetails := MyDetails{
+			Roles: tc.roles,
+		}
+
+		assert.Equal(tc.expected, myDetails.HasRole(tc.search))
+	}
+}

--- a/web/template/pending-cases.gotmpl
+++ b/web/template/pending-cases.gotmpl
@@ -5,7 +5,9 @@
 {{ define "main" }}
   <h1 class="govuk-heading-xl">Your cases</h1>
 
-  {{ template "request-next-case" . }}
+  {{ if .CanRequestCase }}
+    {{ template "request-next-case" . }}
+  {{ end }}
 
   <div class="govuk-tabs" data-module="govuk-tabs">
     <h2 class="govuk-tabs__title">


### PR DESCRIPTION
Non-case workers should not be able to request that cases are assigned to them from the central pot.

This is also enforced in the API, but this change is to make the UI clearer.

Fixes VEGA-855