### PR TITLE
Show task page to Card Payment users

### DIFF
--- a/internal/server/home_redirect.go
+++ b/internal/server/home_redirect.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+)
+
+type HomeRedirectClient interface {
+	MyDetails(sirius.Context) (sirius.MyDetails, error)
+}
+
+func homeRedirect(client HomeRedirectClient) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := getContext(r)
+
+		myDetails, err := client.MyDetails(ctx)
+		if err != nil {
+			return err
+		}
+
+		if myDetails.IsCardPaymentUser() {
+			return RedirectError("/tasks")
+		} else {
+			return RedirectError("/pending-cases")
+		}
+
+	}
+}

--- a/internal/server/home_redirect_test.go
+++ b/internal/server/home_redirect_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHomeRedirectClient struct {
+	myDetails struct {
+		count   int
+		lastCtx sirius.Context
+		data    sirius.MyDetails
+		err     error
+	}
+}
+
+func (m *mockHomeRedirectClient) MyDetails(ctx sirius.Context) (sirius.MyDetails, error) {
+	m.myDetails.count += 1
+	m.myDetails.lastCtx = ctx
+
+	return m.myDetails.data, m.myDetails.err
+}
+
+func TestGetHomeRedirect(t *testing.T) {
+	testCases := map[string]struct {
+		roles            []string
+		ExpectedRedirect string
+	}{
+		"empty": {
+			roles:            []string{},
+			ExpectedRedirect: "/pending-cases",
+		},
+		"casework-team": {
+			roles:            []string{"Manager"},
+			ExpectedRedirect: "/pending-cases",
+		},
+		"card-payment": {
+			roles:            []string{"Card Payment User"},
+			ExpectedRedirect: "/tasks",
+		},
+		"card-payment-manager": {
+			roles:            []string{"Manager", "Card Payment User"},
+			ExpectedRedirect: "/tasks",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			client := &mockHomeRedirectClient{}
+			client.myDetails.data = sirius.MyDetails{
+				Roles: tc.roles,
+			}
+
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest("GET", "/path", nil)
+
+			err := homeRedirect(client)(w, r)
+			assert.Equal(RedirectError(tc.ExpectedRedirect), err)
+		})
+	}
+}
+
+func TestPostHomeRedirect(t *testing.T) {
+	assert := assert.New(t)
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("DELETE", "/path", nil)
+
+	err := feedback(nil, nil)(w, r)
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,7 +39,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/", http.RedirectHandler(prefix+"/pending-cases", http.StatusFound))
+	mux.Handle("/", wrap(homeRedirect(client)))
 
 	mux.Handle("/pending-cases",
 		wrap(

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -18,6 +18,7 @@ type tasksVars struct {
 	HasWorkableCase bool
 	CanRequestCase  bool
 	IsManager       bool
+	ShowCaseTabs    bool
 	XSRFToken       string
 }
 
@@ -50,6 +51,7 @@ func tasks(client TasksClient, tmpl Template) Handler {
 			HasWorkableCase: hasWorkableCase,
 			CanRequestCase:  myDetails.HasRole("Self Allocation User"),
 			IsManager:       myDetails.HasRole("Manager"),
+			ShowCaseTabs:    !myDetails.IsCardPaymentUser(),
 			XSRFToken:       ctx.XSRFToken,
 		})
 	}

--- a/internal/server/tasks_test.go
+++ b/internal/server/tasks_test.go
@@ -122,9 +122,34 @@ func TestGetTasks(t *testing.T) {
 				Pagination:      newPagination(client.casesWithOpenTasksByAssignee.pagination),
 				HasWorkableCase: true,
 				CanRequestCase:  true,
+				ShowCaseTabs:    true,
 			}, template.lastVars)
 		})
 	}
+}
+
+func TestGetTasksHidesCaseTabs(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockTasksClient{}
+	client.casesWithOpenTasksByAssignee.pagination = &sirius.Pagination{}
+	client.myDetails.data = sirius.MyDetails{
+		Roles: []string{"Card Payment User"},
+	}
+
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/path", nil)
+
+	err := tasks(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(tasksVars{
+		Cases:        client.casesWithOpenTasksByAssignee.data,
+		Pagination:   newPagination(&sirius.Pagination{}),
+		ShowCaseTabs: false,
+	}, template.lastVars)
 }
 
 func TestGetTasksMyDetailsError(t *testing.T) {

--- a/internal/sirius/my_details.go
+++ b/internal/sirius/my_details.go
@@ -34,6 +34,10 @@ func (md *MyDetails) IsManager() bool {
 	return md.HasRole("Manager")
 }
 
+func (md *MyDetails) IsCardPaymentUser() bool {
+	return md.HasRole("Card Payment User")
+}
+
 type MyDetailsTeam struct {
 	ID          int    `json:"id"`
 	DisplayName string `json:"displayName"`

--- a/internal/sirius/my_details_test.go
+++ b/internal/sirius/my_details_test.go
@@ -256,3 +256,41 @@ func TestMyDetailsHasRole(t *testing.T) {
 		assert.Equal(tc.expected, myDetails.HasRole(tc.search))
 	}
 }
+
+func TestMyDetailsIsCardPaymentUser(t *testing.T) {
+	testCases := []struct {
+		roles    []string
+		expected bool
+	}{
+		{
+			roles:    []string{},
+			expected: false,
+		},
+		{
+			roles:    []string{"Admin"},
+			expected: false,
+		},
+		{
+			roles:    []string{"Card Payment User"},
+			expected: true,
+		},
+		{
+			roles:    []string{"User", "Card Payment User"},
+			expected: true,
+		},
+		{
+			roles:    []string{"User", "Card Payment User", "Admin"},
+			expected: true,
+		},
+	}
+
+	assert := assert.New(t)
+
+	for _, tc := range testCases {
+		myDetails := MyDetails{
+			Roles: tc.roles,
+		}
+
+		assert.Equal(tc.expected, myDetails.IsCardPaymentUser())
+	}
+}

--- a/web/template/tasks.gotmpl
+++ b/web/template/tasks.gotmpl
@@ -12,15 +12,19 @@
       Contents
     </h2>
     <ul class="govuk-tabs__list">
+      {{ if .ShowCaseTabs }}
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="{{ prefix "/pending-cases" }}">Pending cases</a>
       </li>
+      {{ end }}
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
         <a class="govuk-tabs__tab" href="{{ prefix "/tasks" }}">Tasks</a>
       </li>
+      {{ if .ShowCaseTabs }}
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="{{ prefix "/all-cases" }}">All cases</a>
       </li>
+      {{ end }}
     </ul>
   </div>
 
@@ -59,7 +63,7 @@
         </tr>
       {{ else }}
         <tr>
-          <td colspan="5">You currently have no cases assigned</td>
+          <td colspan="5">You currently have no tasks assigned</td>
         </tr>
       {{ end }}
     </tbody>


### PR DESCRIPTION
If the user is in the Card Payment Team, direct them to the tasks page and hide all other tabs.

Fixes VEGA-1020