### PR TITLE
Always allow Card Payment users to request a task

### DIFF
--- a/internal/server/card_payments.go
+++ b/internal/server/card_payments.go
@@ -13,7 +13,6 @@ type CardPaymentsClient interface {
 
 type cardPaymentsVars struct {
 	Tasks             []sirius.Task
-	HasIncompleteTask bool
 	XSRFToken         string
 }
 
@@ -42,7 +41,6 @@ func cardPayments(client CardPaymentsClient, tmpl Template) Handler {
 
 		vars := cardPaymentsVars{
 			Tasks:             tasks,
-			HasIncompleteTask: len(tasks) > 0,
 			XSRFToken:         ctx.XSRFToken,
 		}
 

--- a/internal/server/card_payments_test.go
+++ b/internal/server/card_payments_test.go
@@ -77,7 +77,6 @@ func TestGetCardPayments(t *testing.T) {
 	assert.Equal("page", template.lastName)
 	assert.Equal(cardPaymentsVars{
 		Tasks:             client.tasksByAssignee.data,
-		HasIncompleteTask: true,
 		XSRFToken:         getContext(r).XSRFToken,
 	}, template.lastVars)
 }

--- a/web/template/card-payments.gotmpl
+++ b/web/template/card-payments.gotmpl
@@ -7,7 +7,7 @@
 
   <form action="{{ prefix "/request-next-payment-task" }}" method="post">
     <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
-    <button {{ if .HasIncompleteTask }}disabled{{ end }} class="govuk-button" type="submit">Request next payment task</button>
+    <button class="govuk-button" type="submit">Request next payment task</button>
   </form>
 
   <table class="govuk-table">


### PR DESCRIPTION
Card Payment users should not be limited to a particular number of tasks, so never disabled the button.

Fixes VEGA-1029 #patch