### PR TITLE
Fix return of HasWorkableCase

### DIFF
--- a/internal/sirius/cases_by_assignee.go
+++ b/internal/sirius/cases_by_assignee.go
@@ -78,5 +78,9 @@ func (c *Client) CasesByAssignee(ctx Context, id int, criteria Criteria) ([]Case
 func (c *Client) HasWorkableCase(ctx Context, id int) (bool, error) {
 	_, pagination, err := c.CasesByAssignee(ctx, id, Criteria{}.Filter("status", "Pending").Filter("worked", "false").Page(1).Limit(1))
 
+	if err != nil {
+		return false, err
+	}
+
 	return pagination.TotalItems > 0, err
 }

--- a/internal/sirius/cases_by_assignee_test.go
+++ b/internal/sirius/cases_by_assignee_test.go
@@ -445,3 +445,17 @@ func TestCasesByAssigneeStatusError(t *testing.T) {
 		Method: http.MethodGet,
 	}, err)
 }
+
+func TestHasWorkableCaseStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.HasWorkableCase(getContext(nil), 47)
+	assert.Equal(t, &StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/assignees/47/cases?filter=status%3APending%2Cworked%3Afalse%2CcaseType%3Alpa%2Cactive%3Atrue&limit=1&page=1",
+		Method: http.MethodGet,
+	}, err)
+}


### PR DESCRIPTION
If `CasesByAssignee` returns an error, we should return it immediately rather than trying to calculate if there's a workable case.

Since the error occurred, pagination is likely to be `nil` and therefore `pagination.TotalItems` causes a panic