### PR TITLE
Pin colors to 1.4.0 #patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "sass-loader": "^10.0.2",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.8.0"
+  },
+  "resolutions": {
+    "colors": "1.4.0"
   }
 }


### PR DESCRIPTION
To ensure we avoid a security issue in >1.4.4.

Can be removed when the package is back under secure control, or our core dependencies stop using it.