### PR TITLE
Bump included cypress image to match NPM version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,39 @@ updates:
       separator: "-"
 
   - package-ecosystem: "docker"
+    directory: "/docker/cypress"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "#patch"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/pact-stub"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "#patch"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: "docker"
+    directory: "/docker/puppeteer"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "#patch"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: "docker"
     directory: "/docker/sirius-lpa-dashboard"
     schedule:
       interval: "daily"

--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:5.2.0
+FROM cypress/included:9.5.3
 
 WORKDIR /root
 


### PR DESCRIPTION
NB: The NPM package is actually on v9.7.0, but ≥9.5.4 upgrades Chrome to v100 and does not run in GitHub Actions ([perhaps due to memory problems?](https://github.com/cypress-io/cypress/issues/21135))

#patch