### PR TITLE
Use security headers from opg-go-common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ministryofjustice/opg-sirius-lpa-dashboard
 go 1.14
 
 require (
+	github.com/ministryofjustice/opg-go-common v0.0.0-20220808113030-11de1e1fac67
 	github.com/pact-foundation/pact-go v1.7.0
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/ministryofjustice/opg-go-common v0.0.0-20220808113030-11de1e1fac67 h1:SzS5byJzdpH69uCsdIoy0BDZpkVmclE8deJE8XSO16E=
+github.com/ministryofjustice/opg-go-common v0.0.0-20220808113030-11de1e1fac67/go.mod h1:1RmCNi6dkAv8umAgNHp8RkuBoSKLlxp1UtfsGYH7ufc=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -208,6 +210,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/ministryofjustice/opg-go-common/securityheaders"
 	"github.com/ministryofjustice/opg-sirius-lpa-dashboard/internal/sirius"
 )
 
@@ -107,20 +108,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	mux.Handle("/javascript/", static)
 	mux.Handle("/stylesheets/", static)
 
-	return http.StripPrefix(prefix, securityHeaders(mux))
-}
-
-func securityHeaders(h http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Security-Policy", "default-src 'self'")
-		w.Header().Add("Referrer-Policy", "same-origin")
-		w.Header().Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
-		w.Header().Add("X-Content-Type-Options", "nosniff")
-		w.Header().Add("X-Frame-Options", "SAMEORIGIN")
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
-
-		h.ServeHTTP(w, r)
-	}
+	return http.StripPrefix(prefix, securityheaders.Use(mux))
 }
 
 type RedirectError string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -41,26 +41,6 @@ func TestNew(t *testing.T) {
 	assert.Implements(t, (*http.Handler)(nil), New(nil, nil, nil, "", "", "", ""))
 }
 
-func TestSecurityHeaders(t *testing.T) {
-	assert := assert.New(t)
-
-	handler := securityHeaders(http.NotFoundHandler())
-
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/path", nil)
-
-	handler.ServeHTTP(w, r)
-
-	resp := w.Result()
-
-	assert.Equal("default-src 'self'", resp.Header.Get("Content-Security-Policy"))
-	assert.Equal("same-origin", resp.Header.Get("Referrer-Policy"))
-	assert.Equal("max-age=31536000; includeSubDomains; preload", resp.Header.Get("Strict-Transport-Security"))
-	assert.Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))
-	assert.Equal("SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
-	assert.Equal("1; mode=block", resp.Header.Get("X-XSS-Protection"))
-}
-
 func TestErrorHandler(t *testing.T) {
 	assert := assert.New(t)
 

--- a/web/template/layout/header.gotmpl
+++ b/web/template/layout/header.gotmpl
@@ -12,10 +12,10 @@
         <nav class="moj-header__navigation" aria-label="Account navigation">
           <ul class="moj-header__navigation-list">
             <li class="moj-header__navigation-item">
-              <a class="moj-header__navigation-link" href="{{ sirius "/lpa" }}" aria-current="page">LPA</a>
+              <a class="moj-header__navigation-link" href="{{ sirius "/lpa" }}">LPA</a>
             </li>
             <li class="moj-header__navigation-item">
-              <a class="moj-header__navigation-link" href="{{ sirius "/supervision" }}" aria-current="page">Supervision</a>
+              <a class="moj-header__navigation-link" href="{{ sirius "/supervision" }}">Supervision</a>
             </li>
             <li class="moj-header__navigation-item">
               <a class="moj-header__navigation-link" href="{{ sirius "/auth/logout" }}">Sign out</a>


### PR DESCRIPTION
Allows us to apply standardised security headers across all apps. Specifically, this app is missing the Cache-Control header.

#patch