### PR TITLE
Move the "Card Payments" page to "Tasks Dashboard"

### DIFF
--- a/cypress/e2e/tasks-dashboard.cy.js
+++ b/cypress/e2e/tasks-dashboard.cy.js
@@ -1,13 +1,13 @@
-describe("Card payments", () => {
+describe("Tasks dashboard", () => {
   beforeEach(() => {
     cy.setCookie("Other", "other");
     cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.visit("/card-payments");
+    cy.visit("/tasks-dashboard");
   });
 
   it("shows your tasks", () => {
-    cy.title().should("contain", "Card payments");
-    cy.get("h1").should("contain", "Card payments");
+    cy.title().should("contain", "my team Dashboard");
+    cy.get("h1").should("contain", "my team Dashboard");
 
     const $row = cy.get("table > tbody > tr");
     $row.should("contain", "Adrian Kurkjian");

--- a/internal/server/redirect.go
+++ b/internal/server/redirect.go
@@ -19,8 +19,8 @@ func redirect(client RedirectClient) Handler {
 			return err
 		}
 
-		if myDetails.IsCardPaymentUser() {
-			return RedirectError("/card-payments")
+		if myDetails.IsSelfAllocationTaskUser() {
+			return RedirectError("/tasks-dashboard")
 		}
 
 		return RedirectError("/pending-cases")

--- a/internal/server/redirect_test.go
+++ b/internal/server/redirect_test.go
@@ -41,17 +41,17 @@ func TestRedirect(t *testing.T) {
 	assert.Equal(getContext(r), client.myDetails.lastCtx)
 }
 
-func TestRedirectCardPaymentUser(t *testing.T) {
+func TestRedirectSelfAllocationTaskUser(t *testing.T) {
 	assert := assert.New(t)
 
 	client := &mockRedirectClient{}
-	client.myDetails.data = sirius.MyDetails{Roles: []string{"Card Payment User"}}
+	client.myDetails.data = sirius.MyDetails{Roles: []string{"Self Allocation Task User"}}
 
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/path", nil)
 
 	err := redirect(client)(w, r)
-	assert.Equal(RedirectError("/card-payments"), err)
+	assert.Equal(RedirectError("/tasks-dashboard"), err)
 
 	assert.Equal(1, client.myDetails.count)
 	assert.Equal(getContext(r), client.myDetails.lastCtx)

--- a/internal/server/request_next_task.go
+++ b/internal/server/request_next_task.go
@@ -20,6 +20,6 @@ func requestNextTask(client RequestNextTaskClient) Handler {
 			return err
 		}
 
-		return RedirectError("/card-payments")
+		return RedirectError("/tasks-dashboard")
 	}
 }

--- a/internal/server/request_next_task_test.go
+++ b/internal/server/request_next_task_test.go
@@ -34,7 +34,7 @@ func TestPostRequestNextTask(t *testing.T) {
 	r, _ := http.NewRequest("POST", "/path", nil)
 
 	err := requestNextTask(client)(w, r)
-	assert.Equal(RedirectError("/card-payments"), err)
+	assert.Equal(RedirectError("/tasks-dashboard"), err)
 
 	assert.Equal(1, client.requestNextTask.count)
 	assert.Equal(getContext(r), client.requestNextTask.lastCtx)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,7 +18,7 @@ type Logger interface {
 
 type Client interface {
 	AllCasesClient
-	CardPaymentsClient
+	TasksDashboardClient
 	CentralCasesClient
 	FeedbackClient
 	MarkWorkedClient
@@ -49,9 +49,9 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 		wrap(
 			pendingCases(client, templates["pending-cases.gotmpl"])))
 
-	mux.Handle("/card-payments",
+	mux.Handle("/tasks-dashboard",
 		wrap(
-			cardPayments(client, templates["card-payments.gotmpl"])))
+			tasksDashboard(client, templates["tasks-dashboard.gotmpl"])))
 
 	mux.Handle("/tasks",
 		wrap(

--- a/internal/sirius/my_details.go
+++ b/internal/sirius/my_details.go
@@ -34,8 +34,8 @@ func (md *MyDetails) IsManager() bool {
 	return md.HasRole("Manager")
 }
 
-func (md *MyDetails) IsCardPaymentUser() bool {
-	return md.HasRole("Card Payment User")
+func (md *MyDetails) IsSelfAllocationTaskUser() bool {
+	return md.HasRole("Self Allocation Task User")
 }
 
 type MyDetailsTeam struct {

--- a/internal/sirius/my_details_test.go
+++ b/internal/sirius/my_details_test.go
@@ -257,7 +257,7 @@ func TestMyDetailsHasRole(t *testing.T) {
 	}
 }
 
-func TestMyDetailsIsCardPaymentUser(t *testing.T) {
+func TestMyDetailsIsSelfAllocationTaskUser(t *testing.T) {
 	testCases := []struct {
 		roles    []string
 		expected bool
@@ -271,15 +271,15 @@ func TestMyDetailsIsCardPaymentUser(t *testing.T) {
 			expected: false,
 		},
 		{
-			roles:    []string{"Card Payment User"},
+			roles:    []string{"Self Allocation Task User"},
 			expected: true,
 		},
 		{
-			roles:    []string{"User", "Card Payment User"},
+			roles:    []string{"User", "Self Allocation Task User"},
 			expected: true,
 		},
 		{
-			roles:    []string{"User", "Card Payment User", "Admin"},
+			roles:    []string{"User", "Self Allocation Task User", "Admin"},
 			expected: true,
 		},
 	}
@@ -291,6 +291,6 @@ func TestMyDetailsIsCardPaymentUser(t *testing.T) {
 			Roles: tc.roles,
 		}
 
-		assert.Equal(tc.expected, myDetails.IsCardPaymentUser())
+		assert.Equal(tc.expected, myDetails.IsSelfAllocationTaskUser())
 	}
 }

--- a/web/template/tasks-dashboard.gotmpl
+++ b/web/template/tasks-dashboard.gotmpl
@@ -1,13 +1,13 @@
 {{ template "page" . }}
 
-{{ define "title" }}Card payments{{ end }}
+{{ define "title" }}{{ .Title }}{{ end }}
 
 {{ define "main" }}
-  <h1 class="govuk-heading-xl">Card payments</h1>
+  <h1 class="govuk-heading-xl">{{ .Title }}</h1>
 
   <form action="{{ prefix "/request-next-task" }}" method="post">
     <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
-    <button class="govuk-button" type="submit">Request next payment task</button>
+    <button class="govuk-button" type="submit">Request next task</button>
   </form>
 
   <table class="govuk-table">


### PR DESCRIPTION
So that it can be used by members of multiple teams.

The page title is now "{team name} Dashboard" rather than being hard-coded as "Card payments"

Fixes VEGA-1445 #major