### PR TITLE
VEGA-1446 remove headers and cookies from pact and cypress tests

### DIFF
--- a/cypress/e2e/all-cases.cy.js
+++ b/cypress/e2e/all-cases.cy.js
@@ -1,7 +1,5 @@
 describe("All cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/all-cases");
   });
 

--- a/cypress/e2e/central-cases.cy.js
+++ b/cypress/e2e/central-cases.cy.js
@@ -1,7 +1,5 @@
 describe("Central pot pending cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/teams/central");
   });
 

--- a/cypress/e2e/feedback.cy.js
+++ b/cypress/e2e/feedback.cy.js
@@ -1,7 +1,5 @@
 describe("Feedback", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/all-cases");
   });
 

--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,7 +1,5 @@
 describe("Case navigation", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/");
   });
 

--- a/cypress/e2e/pending-cases.cy.js
+++ b/cypress/e2e/pending-cases.cy.js
@@ -1,7 +1,5 @@
 describe("Pending cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/pending-cases");
   });
 

--- a/cypress/e2e/reassign.cy.js
+++ b/cypress/e2e/reassign.cy.js
@@ -1,7 +1,5 @@
 describe("Reassign", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/users/pending-cases/47");
   });
 

--- a/cypress/e2e/tasks-dashboard.cy.js
+++ b/cypress/e2e/tasks-dashboard.cy.js
@@ -1,7 +1,5 @@
 describe("Tasks dashboard", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/tasks-dashboard");
   });
 

--- a/cypress/e2e/tasks.cy.js
+++ b/cypress/e2e/tasks.cy.js
@@ -1,7 +1,5 @@
 describe("Tasks", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/tasks");
   });
 

--- a/cypress/e2e/team-work-in-progress.cy.js
+++ b/cypress/e2e/team-work-in-progress.cy.js
@@ -1,7 +1,5 @@
 describe("Team work in progress", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/teams/work-in-progress/66");
   });
 

--- a/cypress/e2e/user-all-cases.cy.js
+++ b/cypress/e2e/user-all-cases.cy.js
@@ -1,7 +1,5 @@
 describe("All of another user's cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/users/all-cases/47");
   });
 

--- a/cypress/e2e/user-pending-cases.cy.js
+++ b/cypress/e2e/user-pending-cases.cy.js
@@ -1,7 +1,5 @@
 describe("Another user's pending cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/users/pending-cases/47");
   });
 

--- a/cypress/e2e/user-tasks.cy.js
+++ b/cypress/e2e/user-tasks.cy.js
@@ -1,7 +1,5 @@
 describe("Another user's tasks", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
     cy.visit("/users/tasks/47");
   });
 

--- a/internal/sirius/assign_test.go
+++ b/internal/sirius/assign_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestAssign(t *testing.T) {
 	testCases := []struct {
 		name          string
 		setup         func()
-		cookies       []*http.Cookie
 		expectedError error
 	}{
 		{
@@ -36,21 +36,11 @@ func TestAssign(t *testing.T) {
 								"id":         dsl.Like(1),
 							}, 1),
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 		},
 	}
@@ -62,7 +52,7 @@ func TestAssign(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.Assign(getContext(tc.cookies), []int{58}, 47)
+				err := client.Assign(Context{Context: context.Background()}, []int{58}, 47)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
@@ -76,7 +66,7 @@ func TestAssignStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	err := client.Assign(getContext(nil), []int{1}, 47)
+	err := client.Assign(Context{Context: context.Background()}, []int{1}, 47)
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/users/47/cases/1",

--- a/internal/sirius/cases_by_assignee_test.go
+++ b/internal/sirius/cases_by_assignee_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -18,7 +19,6 @@ func TestCasesByAssignee(t *testing.T) {
 		name               string
 		criteria           Criteria
 		setup              func()
-		cookies            []*http.Cookie
 		expectedCases      []Case
 		expectedPagination *Pagination
 		expectedError      error
@@ -38,11 +38,6 @@ func TestCasesByAssignee(t *testing.T) {
 							"page":   dsl.String("1"),
 							"filter": dsl.String("caseType:lpa,active:true"),
 							"sort":   dsl.String("receiptDate:asc"),
-						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -70,10 +65,6 @@ func TestCasesByAssignee(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedCases: []Case{{
 				ID:  36,
@@ -111,11 +102,6 @@ func TestCasesByAssignee(t *testing.T) {
 							"filter": dsl.String("status:Pending,caseType:lpa,active:true"),
 							"sort":   dsl.String("receiptDate:asc"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -142,10 +128,6 @@ func TestCasesByAssignee(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedCases: []Case{{
 				ID:  58,
@@ -183,11 +165,6 @@ func TestCasesByAssignee(t *testing.T) {
 							"filter": dsl.String("status:Pending,caseType:lpa,active:true"),
 							"sort":   dsl.String("workedDate:desc,receiptDate:asc"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -214,10 +191,6 @@ func TestCasesByAssignee(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedCases: []Case{{
 				ID:  58,
@@ -256,11 +229,6 @@ func TestCasesByAssignee(t *testing.T) {
 							"filter": dsl.String("status:Pending,caseType:lpa,active:true"),
 							"sort":   dsl.String("receiptDate:asc"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -287,10 +255,6 @@ func TestCasesByAssignee(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedCases: []Case{{
 				ID:  453,
@@ -321,7 +285,7 @@ func TestCasesByAssignee(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				cases, pagination, err := client.CasesByAssignee(getContext(tc.cookies), 47, tc.criteria)
+				cases, pagination, err := client.CasesByAssignee(Context{Context: context.Background()}, 47, tc.criteria)
 				assert.Equal(t, tc.expectedCases, cases)
 				assert.Equal(t, tc.expectedPagination, pagination)
 				assert.Equal(t, tc.expectedError, err)
@@ -339,7 +303,6 @@ func TestHasWorkableCase(t *testing.T) {
 		name          string
 		criteria      Criteria
 		setup         func()
-		cookies       []*http.Cookie
 		expectedError error
 	}{
 		{
@@ -356,11 +319,6 @@ func TestHasWorkableCase(t *testing.T) {
 							"page":   dsl.String("1"),
 							"limit":  dsl.String("1"),
 							"filter": dsl.String("status:Pending,worked:false,caseType:lpa,active:true"),
-						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -389,10 +347,6 @@ func TestHasWorkableCase(t *testing.T) {
 						}),
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 		},
 	}
 
@@ -403,7 +357,7 @@ func TestHasWorkableCase(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				ok, err := client.HasWorkableCase(getContext(tc.cookies), 47)
+				ok, err := client.HasWorkableCase(Context{Context: context.Background()}, 47)
 				assert.True(t, ok)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -418,7 +372,7 @@ func TestCasesByAssigneeStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, _, err := client.CasesByAssignee(getContext(nil), 47, Criteria{}.Page(2))
+	_, _, err := client.CasesByAssignee(Context{Context: context.Background()}, 47, Criteria{}.Page(2))
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/assignees/47/cases?filter=caseType%3Alpa%2Cactive%3Atrue&page=2",
@@ -432,7 +386,7 @@ func TestHasWorkableCaseStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.HasWorkableCase(getContext(nil), 47)
+	_, err := client.HasWorkableCase(Context{Context: context.Background()}, 47)
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/assignees/47/cases?filter=status%3APending%2Cworked%3Afalse%2CcaseType%3Alpa%2Cactive%3Atrue&limit=1&page=1",

--- a/internal/sirius/cases_by_team_test.go
+++ b/internal/sirius/cases_by_team_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -18,7 +19,6 @@ func TestCasesByTeam(t *testing.T) {
 		name           string
 		criteria       Criteria
 		setup          func()
-		cookies        []*http.Cookie
 		expectedResult *CasesByTeam
 		expectedError  error
 	}{
@@ -35,11 +35,6 @@ func TestCasesByTeam(t *testing.T) {
 						Path:   dsl.String("/api/v1/teams/66/cases"),
 						Query: dsl.MapMatcher{
 							"page": dsl.String("1"),
-						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -88,10 +83,6 @@ func TestCasesByTeam(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResult: &CasesByTeam{
 				Cases: []Case{{
@@ -145,7 +136,7 @@ func TestCasesByTeam(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				result, err := client.CasesByTeam(getContext(tc.cookies), 66, tc.criteria)
+				result, err := client.CasesByTeam(Context{Context: context.Background()}, 66, tc.criteria)
 				assert.Equal(t, tc.expectedResult, result)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -162,7 +153,6 @@ func TestCasesByTeamIgnored(t *testing.T) {
 		name           string
 		criteria       Criteria
 		setup          func()
-		cookies        []*http.Cookie
 		expectedResult *CasesByTeam
 		expectedError  error
 	}{
@@ -180,11 +170,6 @@ func TestCasesByTeamIgnored(t *testing.T) {
 						Query: dsl.MapMatcher{
 							"page":   dsl.String("1"),
 							"filter": dsl.String("allocation:47"),
-						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -233,10 +218,6 @@ func TestCasesByTeamIgnored(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResult: &CasesByTeam{
 				Cases: []Case{{
@@ -290,7 +271,7 @@ func TestCasesByTeamIgnored(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				result, err := client.CasesByTeam(getContext(tc.cookies), 66, tc.criteria)
+				result, err := client.CasesByTeam(Context{Context: context.Background()}, 66, tc.criteria)
 				assert.Equal(t, tc.expectedResult, result)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -305,7 +286,7 @@ func TestCasesByTeamStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.CasesByTeam(getContext(nil), 66, Criteria{}.Page(2))
+	_, err := client.CasesByTeam(Context{Context: context.Background()}, 66, Criteria{}.Page(2))
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/teams/66/cases?page=2",

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -1,7 +1,6 @@
 package sirius
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,14 +39,6 @@ func teapotServer() *httptest.Server {
 			w.WriteHeader(http.StatusTeapot)
 		}),
 	)
-}
-
-func getContext(cookies []*http.Cookie) Context {
-	return Context{
-		Context:   context.Background(),
-		Cookies:   cookies,
-		XSRFToken: "abcde",
-	}
 }
 
 func TestClientError(t *testing.T) {

--- a/internal/sirius/feedback_test.go
+++ b/internal/sirius/feedback_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestFeedback(t *testing.T) {
 	testCases := []struct {
 		name          string
 		setup         func()
-		cookies       []*http.Cookie
 		expectedError error
 	}{
 		{
@@ -32,21 +32,11 @@ func TestFeedback(t *testing.T) {
 						Body: dsl.Like(map[string]interface{}{
 							"message": dsl.String("hey"),
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 		},
 	}
@@ -58,7 +48,7 @@ func TestFeedback(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.Feedback(getContext(tc.cookies), "hey")
+				err := client.Feedback(Context{Context: context.Background()}, "hey")
 				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
@@ -72,7 +62,7 @@ func TestFeedbackStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	err := client.Feedback(getContext(nil), "hey")
+	err := client.Feedback(Context{Context: context.Background()}, "hey")
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/wth",

--- a/internal/sirius/my_details_test.go
+++ b/internal/sirius/my_details_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestMyDetails(t *testing.T) {
 	testCases := []struct {
 		name              string
 		setup             func()
-		cookies           []*http.Cookie
 		expectedMyDetails MyDetails
 		expectedError     error
 	}{
@@ -30,11 +30,6 @@ func TestMyDetails(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/users/current"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -48,10 +43,6 @@ func TestMyDetails(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedMyDetails: MyDetails{
 				ID:    47,
@@ -68,7 +59,7 @@ func TestMyDetails(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				myDetails, err := client.MyDetails(getContext(tc.cookies))
+				myDetails, err := client.MyDetails(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedMyDetails, myDetails)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -84,7 +75,6 @@ func TestMyDetailsIgnored(t *testing.T) {
 	testCases := []struct {
 		name              string
 		setup             func()
-		cookies           []*http.Cookie
 		expectedMyDetails MyDetails
 		expectedError     error
 	}{
@@ -98,11 +88,6 @@ func TestMyDetailsIgnored(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/users/current"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -116,10 +101,6 @@ func TestMyDetailsIgnored(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedMyDetails: MyDetails{
 				ID:    47,
@@ -136,7 +117,7 @@ func TestMyDetailsIgnored(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				myDetails, err := client.MyDetails(getContext(tc.cookies))
+				myDetails, err := client.MyDetails(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedMyDetails, myDetails)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -151,7 +132,7 @@ func TestMyDetailsStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.MyDetails(getContext(nil))
+	_, err := client.MyDetails(Context{Context: context.Background()})
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/users/current",

--- a/internal/sirius/request_next_cases_test.go
+++ b/internal/sirius/request_next_cases_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestRequestNextCases(t *testing.T) {
 	testCases := []struct {
 		name          string
 		setup         func()
-		cookies       []*http.Cookie
 		expectedError error
 	}{
 		{
@@ -29,20 +29,11 @@ func TestRequestNextCases(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
 						Path:   dsl.String("/api/v1/request-new-cases"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 		},
 	}
@@ -54,7 +45,7 @@ func TestRequestNextCases(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.RequestNextCases(getContext(tc.cookies))
+				err := client.RequestNextCases(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
@@ -68,7 +59,7 @@ func TestRequestNextCasesStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	err := client.RequestNextCases(getContext(nil))
+	err := client.RequestNextCases(Context{Context: context.Background()})
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/request-new-cases",

--- a/internal/sirius/request_next_task_test.go
+++ b/internal/sirius/request_next_task_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestRequestNextTask(t *testing.T) {
 	testCases := []struct {
 		name          string
 		setup         func()
-		cookies       []*http.Cookie
 		expectedError error
 	}{
 		{
@@ -29,20 +29,11 @@ func TestRequestNextTask(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
 						Path:   dsl.String("/api/v1/request-new-task"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 		},
 	}
@@ -54,7 +45,7 @@ func TestRequestNextTask(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.RequestNextTask(getContext(tc.cookies))
+				err := client.RequestNextTask(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
@@ -68,7 +59,7 @@ func TestRequestNextTaskStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	err := client.RequestNextTask(getContext(nil))
+	err := client.RequestNextTask(Context{Context: context.Background()})
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/request-new-task",

--- a/internal/sirius/team_test.go
+++ b/internal/sirius/team_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -17,7 +18,6 @@ func TestTeam(t *testing.T) {
 		id               int
 		name             string
 		setup            func()
-		cookies          []*http.Cookie
 		expectedResponse Team
 		expectedError    error
 	}{
@@ -32,11 +32,6 @@ func TestTeam(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/teams/66"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -50,10 +45,6 @@ func TestTeam(t *testing.T) {
 							}, 1),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResponse: Team{
 				ID:          66,
@@ -75,7 +66,7 @@ func TestTeam(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				team, err := client.Team(getContext(tc.cookies), tc.id)
+				team, err := client.Team(Context{Context: context.Background()}, tc.id)
 				assert.Equal(t, tc.expectedResponse, team)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -90,7 +81,7 @@ func TestTeamStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.Team(getContext(nil), 123)
+	_, err := client.Team(Context{Context: context.Background()}, 123)
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/teams/123",

--- a/internal/sirius/teams_test.go
+++ b/internal/sirius/teams_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestTeams(t *testing.T) {
 	testCases := []struct {
 		name             string
 		setup            func()
-		cookies          []*http.Cookie
 		expectedResponse []Team
 		expectedError    error
 	}{
@@ -30,11 +30,6 @@ func TestTeams(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/teams"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -44,10 +39,6 @@ func TestTeams(t *testing.T) {
 							"displayName": dsl.Like("Cool Team"),
 						}, 1),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResponse: []Team{
 				{
@@ -66,7 +57,7 @@ func TestTeams(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				users, err := client.Teams(getContext(tc.cookies))
+				users, err := client.Teams(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedResponse, users)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -82,7 +73,6 @@ func TestTeamsIgnored(t *testing.T) {
 	testCases := []struct {
 		name             string
 		setup            func()
-		cookies          []*http.Cookie
 		expectedResponse []Team
 		expectedError    error
 	}{
@@ -96,11 +86,6 @@ func TestTeamsIgnored(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/api/v1/teams"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -114,10 +99,6 @@ func TestTeamsIgnored(t *testing.T) {
 							}, 1),
 						}, 1),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResponse: []Team{
 				{
@@ -139,7 +120,7 @@ func TestTeamsIgnored(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				users, err := client.Teams(getContext(tc.cookies))
+				users, err := client.Teams(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedResponse, users)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -154,7 +135,7 @@ func TestTeamsStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.Teams(getContext(nil))
+	_, err := client.Teams(Context{Context: context.Background()})
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/teams",

--- a/internal/sirius/user_by_email_test.go
+++ b/internal/sirius/user_by_email_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +17,6 @@ func TestUserByEmail(t *testing.T) {
 	testCases := []struct {
 		name          string
 		setup         func()
-		cookies       []*http.Cookie
 		email         string
 		expectedUser  User
 		expectedError error
@@ -35,11 +35,6 @@ func TestUserByEmail(t *testing.T) {
 						Query: dsl.MapMatcher{
 							"email": dsl.String("manager@opgtest.com"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -48,10 +43,6 @@ func TestUserByEmail(t *testing.T) {
 							"id": dsl.Like(47),
 						}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedUser: User{
 				ID: 47,
@@ -66,7 +57,7 @@ func TestUserByEmail(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				user, err := client.UserByEmail(getContext(tc.cookies), tc.email)
+				user, err := client.UserByEmail(Context{Context: context.Background()}, tc.email)
 				assert.Equal(t, tc.expectedUser, user)
 				assert.Equal(t, tc.expectedError, err)
 				return nil
@@ -81,7 +72,7 @@ func TestUserByEmailStatusError(t *testing.T) {
 
 	client, _ := NewClient(http.DefaultClient, s.URL)
 
-	_, err := client.UserByEmail(getContext(nil), "someone@opgtest.com")
+	_, err := client.UserByEmail(Context{Context: context.Background()}, "someone@opgtest.com")
 	assert.Equal(t, &StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/users?email=someone@opgtest.com",


### PR DESCRIPTION
Pact requests are now authenticated sirius side so there is no need to set headers and cookies in pact/cypress tests.
#minor