### PR TITLE
Use cypress-io/github-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,9 +191,21 @@ jobs:
         run: |
           docker load -i /tmp/images/app.tar
           docker load -i /tmp/images/pact-stub.tar
-      - name: Run cypress
+      - name: Start app
         run: |
-          docker-compose -f docker/docker-compose.ci.yml run cypress
+          docker-compose -f docker/docker-compose.ci.yml up -d pact-stub app
+
+      - name: Cypress Tests
+        uses: cypress-io/github-action@v5.0.2
+        with:
+          browser: chrome
+
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
 
   push:
     name: "Build & Push Containers"

--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -1,9 +1,0 @@
-FROM cypress/included:11.2.0
-
-WORKDIR /root
-
-ENV CYPRESS_VIDEO=false
-ENV CYPRESS_baseUrl=http://app:8888
-
-COPY cypress.config.js .
-COPY cypress cypress

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -32,15 +32,6 @@ services:
       - LHCI_BUILD_CONTEXT__GITHUB_REPO_SLUG=ministryofjustice/opg-sirius-lpa-dashboard
       - LHCI_GITHUB_APP_TOKEN
 
-  cypress:
-    build:
-      context: ..
-      dockerfile: ./docker/cypress/Dockerfile
-    command: ["--headless", "-b", "chrome"]
-    depends_on:
-      - app
-      - pact-stub
-
 volumes:
   pacts_data:
     name: pacts_data


### PR DESCRIPTION
Use the prebuilt GitHub Action rather than maintaining our own image. This also means that everything uses the Cypress version specified in `package.json`.

#patch