### PR TITLE
Bump node image to 18.13.0-alpine3.17

### DIFF
--- a/docker/sirius-lpa-dashboard/Dockerfile
+++ b/docker/sirius-lpa-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.3.0-alpine3.12 as asset-env
+FROM node:18.13.0-alpine3.17 as asset-env
 
 WORKDIR /app
 


### PR DESCRIPTION
Moves Node to LTS release and a more recent version of Alpine

#patch