### PR TITLE
Ignore gosec false positives

### DIFF
--- a/internal/sirius/assign.go
+++ b/internal/sirius/assign.go
@@ -49,7 +49,7 @@ func (c *Client) Assign(ctx Context, cases []int, assignee int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/cases_by_assignee.go
+++ b/internal/sirius/cases_by_assignee.go
@@ -49,7 +49,7 @@ func (c *Client) CasesByAssignee(ctx Context, id int, criteria Criteria) ([]Case
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, nil, ErrUnauthorized

--- a/internal/sirius/cases_by_team.go
+++ b/internal/sirius/cases_by_team.go
@@ -35,7 +35,7 @@ func (c *Client) CasesByTeam(ctx Context, id int, criteria Criteria) (*CasesByTe
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized

--- a/internal/sirius/cases_with_open_tasks_by_assignee.go
+++ b/internal/sirius/cases_with_open_tasks_by_assignee.go
@@ -23,7 +23,7 @@ func (c *Client) CasesWithOpenTasksByAssignee(ctx Context, id, page int) ([]Case
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, nil, ErrUnauthorized

--- a/internal/sirius/feedback.go
+++ b/internal/sirius/feedback.go
@@ -29,7 +29,7 @@ func (c *Client) Feedback(ctx Context, message string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/mark_worked.go
+++ b/internal/sirius/mark_worked.go
@@ -16,7 +16,7 @@ func (c *Client) MarkWorked(ctx Context, id int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/my_details.go
+++ b/internal/sirius/my_details.go
@@ -55,7 +55,7 @@ func (c *Client) MyDetails(ctx Context) (MyDetails, error) {
 	if err != nil {
 		return v, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return v, ErrUnauthorized

--- a/internal/sirius/request_next_cases.go
+++ b/internal/sirius/request_next_cases.go
@@ -14,7 +14,7 @@ func (c *Client) RequestNextCases(ctx Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/request_next_task.go
+++ b/internal/sirius/request_next_task.go
@@ -14,7 +14,7 @@ func (c *Client) RequestNextTask(ctx Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/tasks_by_assignee.go
+++ b/internal/sirius/tasks_by_assignee.go
@@ -37,7 +37,7 @@ func (c *Client) TasksByAssignee(ctx Context, id int, criteria Criteria) ([]Task
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, nil, ErrUnauthorized

--- a/internal/sirius/team.go
+++ b/internal/sirius/team.go
@@ -16,7 +16,7 @@ func (c *Client) Team(ctx Context, id int) (Team, error) {
 	if err != nil {
 		return Team{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return Team{}, ErrUnauthorized

--- a/internal/sirius/teams.go
+++ b/internal/sirius/teams.go
@@ -36,7 +36,7 @@ func (c *Client) Teams(ctx Context) ([]Team, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized

--- a/internal/sirius/user.go
+++ b/internal/sirius/user.go
@@ -20,7 +20,7 @@ func (c *Client) User(ctx Context, id int) (Assignee, error) {
 	if err != nil {
 		return v, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return v, ErrUnauthorized

--- a/internal/sirius/user_by_email.go
+++ b/internal/sirius/user_by_email.go
@@ -24,7 +24,7 @@ func (c *Client) UserByEmail(ctx Context, email string) (User, error) {
 	if err != nil {
 		return User{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return User{}, ErrUnauthorized


### PR DESCRIPTION
We don't care about errors when closing the body of an API request

Fixes VEGA-1706 #patch