### PR TITLE
Disable lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,6 @@
         "Dependencies",
         "Renovate"
     ],
-    "lockFileMaintenance": {
-        "enabled": true
-    },
     "packageRules": [
         {
             "automerge": true,


### PR DESCRIPTION
Turn off lockfile maintenance in Renovate: it only updates transient dependencies, which creates lots of noise and doesn't provide us with any benefit