### PR TITLE
Set branchNameStrict to true to fix branch name formatting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
         "config:base"
     ],
     "branchPrefix": "renovate-",
+    "branchNameStrict": true,
     "commitMessageAction": "Renovate Update",
     "labels": [
         "Dependencies",


### PR DESCRIPTION
This fixes the branch name formatting issues that cause renovate PRs to fail builds