### PR TITLE
Improve handling of Sirius API errors

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,10 +168,16 @@ func errorHandler(tmplError Template, prefix, siriusURL string) func(next Handle
 				}
 
 				code := http.StatusInternalServerError
+				message := err.Error()
 				if status, ok := err.(StatusError); ok {
 					if status.Code() == http.StatusForbidden || status.Code() == http.StatusNotFound {
 						code = status.Code()
 					}
+				}
+
+				if statusError, ok := err.(*sirius.StatusError); ok {
+					code = statusError.Code
+					message = statusError.Title()
 				}
 
 				logger := telemetry.LoggerFromContext(r.Context())
@@ -184,7 +190,7 @@ func errorHandler(tmplError Template, prefix, siriusURL string) func(next Handle
 					SiriusURL: siriusURL,
 					Path:      "",
 					Code:      code,
-					Error:     err.Error(),
+					Error:     message,
 				})
 
 				if err != nil {


### PR DESCRIPTION
If the API responds with a HTTP status error, copy the status code from that error onto the response.

This makes the status code and response the user sees more accurate. For example, if Sirius returns a 403 response the user will now see a "Forbidden" page rather than "An error has occurred".

This also stops error-level logging of 4XX responses.

Fixes CTC-175 #patch