### PR TITLE
Upgrade frontend libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^8.0.0",
+        "@ministryofjustice/frontend": "^9.0.0",
         "cypress": "15.13.0",
-        "govuk-frontend": "^5.0.0"
+        "govuk-frontend": "^6.1.0"
       },
       "devDependencies": {
         "esbuild": "^0.28.0",
@@ -510,15 +510,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-8.0.1.tgz",
-      "integrity": "sha512-IPgCcNe+XKV55I4J/SIoYAkfYp7mmUKjO1igXhzOtcF05+stWPbJuL9QzKORlRUxkwZtQ1jmiY7PZxMQzOXniw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.11.2",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^8.0.0",
+    "@ministryofjustice/frontend": "^9.0.0",
     "cypress": "15.13.0",
-    "govuk-frontend": "^5.0.0"
+    "govuk-frontend": "^6.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.28.0",

--- a/web/assets/_filters.scss
+++ b/web/assets/_filters.scss
@@ -2,7 +2,7 @@
   position: relative;
   padding: 0 0 10px;
   margin-bottom: 10px;
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
 }
 
 .app-c-option-select__heading {
@@ -18,7 +18,7 @@
   text-align: left;
   padding: 0;
   cursor: pointer;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
 }
 
 .app-c-option-select__title {

--- a/web/assets/_filters.scss
+++ b/web/assets/_filters.scss
@@ -33,7 +33,7 @@
   left: 9px;
   width: 30px;
   height: 40px;
-  fill: #0b0c0c;
+  fill: govuk-functional-colour(text);
 }
 
 [aria-expanded="true"] ~ .app-c-option-select__icon--up {

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -2,7 +2,7 @@ $govuk-page-width: 1220px;
 $moj-page-width: 1220px;
 $govuk-assets-path: "/lpa/dashboard/assets/";
 
-@import "node_modules/govuk-frontend/dist/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 @import "filters";
 
@@ -16,7 +16,7 @@ $govuk-assets-path: "/lpa/dashboard/assets/";
 }
 
 .app-background-blue {
-  background: $govuk-brand-colour;
+  background: govuk-functional-colour(brand);
 }
 
 .app-color-white {


### PR DESCRIPTION
Upgrade govuk-frontend to v6, and @ministryofjustice/frontend to v9.

Update imports.

Replace `$govuk-XXX-colour` with `govuk-functional-colour(XXX)`

For VEGA-3810 #patch