### PR TITLE
Update theme-color to #1d70b8

### DIFF
--- a/web/template/layout/page.gotmpl
+++ b/web/template/layout/page.gotmpl
@@ -5,7 +5,7 @@
       <meta charset="utf-8">
       <title>{{ block "title" . }}{{ end }} - Sirius</title>
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-      <meta name="theme-color" content="blue">
+      <meta name="theme-color" content="#1d70b8">
 
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
 


### PR DESCRIPTION
To match the GOV.UK template, and provide a less-jarring colour to browsers that make use of it.

#patch